### PR TITLE
Remove qed emoji

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -105,7 +105,7 @@ main = do
                       results' = handleRes <$> rs
                       ok = not $ or $ fst <$> results'
                   if ok
-                  then putStrLn $ msg <> "Q.E.D ✨"
+                  then putStrLn $ msg <> "Q.E.D."
                   else do
                       putStrLn $ msg <> "\n\n" <> intercalate sep (snd <$> results')
                       exitFailure


### PR DESCRIPTION
Since it breaks the output of the SMT backend if the user's terminal does not support emojis