### PR TITLE
Type: fail if storage reads are undeclared

### DIFF
--- a/docs/act.md
+++ b/docs/act.md
@@ -50,12 +50,12 @@ returns x + y
 
 In more verbose terms, this specification would read:
 
-Given any pair of integers x and y, s.t. 0 <= x < 2^256 and
-0 <= y < 2^256, an ABI encoded call to the contract `SafeMath`
-with the signature "add(uint256,uint256)", and x and y, will:
-    -   return x + y      if 0 <= x + y < 2^256
-    -   revert            otherwise
+Given any pair of integers `x` and `y`, s.t. `0 <= x < 2^256` and
+`0 <= y < 2^256`, an ABI encoded call to the contract `SafeMath`
+with the signature `add(uint256,uint256)`, and `x` and `y`, will:
 
+-   return `x + y`      if `0 <= x + y < 2^256`
+-   revert              otherwise
 
 ## Contructor
 
@@ -228,3 +228,23 @@ ensures
 
    x == _x
 ```
+
+## Referencing Storage Variables
+
+Storage locations that are read and used in other expressions must be declared in a storage block.
+
+Some examples:
+
+```act
+storage
+  x => y
+  y
+```
+
+```act
+storage
+  x
+  y
+
+returns x + y
+``

--- a/tests/coq/exponent/exponent.act
+++ b/tests/coq/exponent/exponent.act
@@ -28,3 +28,4 @@ storage
 
     r => r * b
     e => e - 1
+    b

--- a/tests/frontend/fail/missingdef0.act
+++ b/tests/frontend/fail/missingdef0.act
@@ -1,0 +1,15 @@
+constructor of Fail
+interface constructor()
+
+creates
+
+	uint x := 0
+	uint y := 2
+
+// should fail to typecheck because y has not been declared in the storage block below...
+behaviour f of Fail
+interface f()
+
+storage
+
+	x => y

--- a/tests/frontend/fail/missingdef1.act
+++ b/tests/frontend/fail/missingdef1.act
@@ -1,0 +1,13 @@
+constructor of Fail
+interface constructor()
+
+creates
+
+	uint x := 0
+	uint y := 2
+
+// should fail to typecheck because x & y have not been declared in a storage block
+behaviour g of Fail
+interface g()
+
+returns x + y

--- a/tests/frontend/fail/missingdef2.act
+++ b/tests/frontend/fail/missingdef2.act
@@ -1,0 +1,23 @@
+constructor of C
+interface constructor()
+
+creates
+
+    uint x := 1
+    uint y := 1
+
+
+constructor of B
+interface constructor()
+
+creates
+
+    uint a := 1
+    uint b := 1
+
+behaviour f of B
+interface f()
+
+storage C
+
+    x => y

--- a/tests/frontend/pass/storageread0.act
+++ b/tests/frontend/pass/storageread0.act
@@ -1,0 +1,15 @@
+constructor of Pass
+interface constructor()
+
+creates
+
+	uint x := 0
+	uint y := 2
+
+behaviour f of Pass
+interface f()
+
+storage
+
+	x => y
+    y

--- a/tests/frontend/pass/storageread1.act
+++ b/tests/frontend/pass/storageread1.act
@@ -1,0 +1,22 @@
+constructor of Pass
+interface constructor()
+
+creates
+
+    uint x := 0
+    uint y := 2
+
+behaviour g of Pass
+interface g()
+
+iff in range uint256
+
+    x + y
+
+storage
+
+    // TODO: remove this hack once bug #81 is fixed...
+    x => x
+    y
+
+returns x + y

--- a/tests/frontend/pass/storageread2.act
+++ b/tests/frontend/pass/storageread2.act
@@ -1,0 +1,24 @@
+constructor of C
+interface constructor()
+
+creates
+
+    uint x := 1
+    uint y := 1
+
+
+constructor of B
+interface constructor()
+
+creates
+
+    uint a := 1
+    uint b := 1
+
+behaviour f of B
+interface f()
+
+storage C
+
+    x => y
+    y

--- a/tests/hevm/fail/unspecced_storage/unspecced_storage.act
+++ b/tests/hevm/fail/unspecced_storage/unspecced_storage.act
@@ -1,4 +1,4 @@
-behaviour constructor of A
+constructor of A
 interface constructor()
 
 creates


### PR DESCRIPTION
We now throw a type error if a storage read is not declared within the storage block.

e.g. The following will now fail with a type error (even if `y` is declared in the constructor).

```
storage
  x => y
```

The following is correct:

```
storage
  x => y
  y
```

This fixes #75.