### PR TITLE
Lex: allow negative integer literals

### DIFF
--- a/src/Lex.x
+++ b/src/Lex.x
@@ -20,6 +20,7 @@ $digit = 0-9                    -- digits
 $alpha = [a-z A-Z]              -- alphabetic characters
 $ident = [$alpha _]
 $space = [\ \t\f\v\r]
+$negative = \-
 
 tokens :-
 
@@ -111,7 +112,8 @@ tokens :-
   $ident ($ident | $digit)*             { \ p s -> L (ID s) p }
 
   -- literals
-  $digit+                               { \ p s -> L (ILIT (read s)) p }
+  $negative? $digit+                    { \ p s -> L (ILIT (read s)) p }
+
 {
 
 data LEX =

--- a/src/test/Test.hs
+++ b/src/test/Test.hs
@@ -154,10 +154,10 @@ genExpBool names n = oneof
         subExpInt = genExpInt names (n `div` 2)
 
 
--- TODO: storage, negative literals
+-- TODO: storage
 genExpInt :: Names -> Int -> Gen (Exp Integer)
 genExpInt names 0 = oneof
-  [ LitInt . abs <$> arbitrary
+  [ LitInt <$> arbitrary
   , IntVar <$> (selectName Integer names)
   , return $ IntEnv Caller
   , return $ IntEnv Callvalue

--- a/tests/frontend/pass/negative-literals.act
+++ b/tests/frontend/pass/negative-literals.act
@@ -1,0 +1,6 @@
+constructor of C
+interface constructor()
+
+creates
+
+    int totalSupply := -1


### PR DESCRIPTION
Fixes #61.

This does not include any typechecker logic, so obviously wrong statements like `uint a := -1` are admitted. A general check at the typechecker level would require us to implement evaluation for integer expressions, so I think it's fine to keep the implementation simple and leave this for the bounds checker.