### PR TITLE
Refactor: Enrich Invariants

### DIFF
--- a/src/Extract.hs
+++ b/src/Extract.hs
@@ -1,0 +1,204 @@
+{-# LANGUAGE GADTs #-}
+
+module Extract where
+
+import qualified Data.List.NonEmpty as NonEmpty
+
+import RefinedAst
+import Syntax
+
+locsFromReturnExp :: ReturnExp -> [StorageLocation]
+locsFromReturnExp (ExpInt e) = locsFromExp e
+locsFromReturnExp (ExpBool e) = locsFromExp e
+locsFromReturnExp (ExpBytes e) = locsFromExp e
+
+locsFromExp :: Exp a -> [StorageLocation]
+locsFromExp e = case e of
+  And a b   -> (locsFromExp a) <> (locsFromExp b)
+  Or a b    -> (locsFromExp a) <> (locsFromExp b)
+  Impl a b  -> (locsFromExp a) <> (locsFromExp b)
+  Eq a b    -> (locsFromExp a) <> (locsFromExp b)
+  LE a b    -> (locsFromExp a) <> (locsFromExp b)
+  LEQ a b   -> (locsFromExp a) <> (locsFromExp b)
+  GE a b    -> (locsFromExp a) <> (locsFromExp b)
+  GEQ a b   -> (locsFromExp a) <> (locsFromExp b)
+  NEq a b   -> (locsFromExp a) <> (locsFromExp b)
+  Neg a     -> (locsFromExp a)
+  Add a b   -> (locsFromExp a) <> (locsFromExp b)
+  Sub a b   -> (locsFromExp a) <> (locsFromExp b)
+  Mul a b   -> (locsFromExp a) <> (locsFromExp b)
+  Div a b   -> (locsFromExp a) <> (locsFromExp b)
+  Mod a b   -> (locsFromExp a) <> (locsFromExp b)
+  Exp a b   -> (locsFromExp a) <> (locsFromExp b)
+  Cat a b   -> (locsFromExp a) <> (locsFromExp b)
+  Slice a b c -> (locsFromExp a) <> (locsFromExp b) <> (locsFromExp c)
+  ByVar _ -> []
+  ByStr _ -> []
+  ByLit _ -> []
+  LitInt _  -> []
+  IntMin _  -> []
+  IntMax _  -> []
+  UIntMin _ -> []
+  UIntMax _ -> []
+  IntVar _  -> []
+  LitBool _ -> []
+  BoolVar _ -> []
+  NewAddr _ _ -> error "TODO: handle new addr in SMT expressions"
+  IntEnv _ -> []
+  ByEnv _ -> []
+  ITE x y z -> (locsFromExp x) <> (locsFromExp y) <> (locsFromExp z)
+  TEntry a -> case a of
+    DirectInt contract name -> [IntLoc $ DirectInt contract name]
+    DirectBool contract slot -> [BoolLoc $ DirectBool contract slot]
+    DirectBytes contract slot -> [BytesLoc $ DirectBytes contract slot]
+    MappedInt contract name ixs -> [IntLoc $ MappedInt contract name ixs] <> ixLocs ixs
+    MappedBool contract name ixs -> [BoolLoc $ MappedBool contract name ixs] <> ixLocs ixs
+    MappedBytes contract name ixs -> [BytesLoc $ MappedBytes contract name ixs] <> ixLocs ixs
+    where
+      ixLocs :: NonEmpty.NonEmpty ReturnExp -> [StorageLocation]
+      ixLocs = concatMap locsFromReturnExp
+
+ethEnvFromBehaviour :: Behaviour -> [EthEnv]
+ethEnvFromBehaviour (Behaviour _ _ _ _ preconds postconds stateUpdates returns) =
+  (concatMap ethEnvFromExp preconds)
+  <> (concatMap ethEnvFromExp postconds)
+  <> (concatMap ethEnvFromStateUpdate stateUpdates)
+  <> (maybe [] ethEnvFromReturnExp returns)
+
+ethEnvFromConstructor :: Constructor -> [EthEnv]
+ethEnvFromConstructor (Constructor _ _ _ pre post initialStorage stateUpdates) =
+  (concatMap ethEnvFromExp pre)
+  <> (concatMap ethEnvFromExp post)
+  <> (concatMap ethEnvFromStateUpdate stateUpdates)
+  <> (concatMap ethEnvFromStateUpdate (Right <$> initialStorage))
+
+ethEnvFromStateUpdate :: Either StorageLocation StorageUpdate -> [EthEnv]
+ethEnvFromStateUpdate update = case update of
+  Left (IntLoc item) -> ethEnvFromItem item
+  Left (BoolLoc item) -> ethEnvFromItem item
+  Left (BytesLoc item) -> ethEnvFromItem item
+  Right (IntUpdate item e) -> ethEnvFromItem item <> ethEnvFromExp e
+  Right (BoolUpdate item e) -> ethEnvFromItem item <> ethEnvFromExp e
+  Right (BytesUpdate item e) -> ethEnvFromItem item <> ethEnvFromExp e
+
+ethEnvFromItem :: TStorageItem a -> [EthEnv]
+ethEnvFromItem item = case item of
+  MappedInt _ _ ixs -> concatMap ethEnvFromReturnExp ixs
+  MappedBool _ _ ixs -> concatMap ethEnvFromReturnExp ixs
+  MappedBytes _ _ ixs -> concatMap ethEnvFromReturnExp ixs
+  _ -> []
+
+ethEnvFromReturnExp :: ReturnExp -> [EthEnv]
+ethEnvFromReturnExp (ExpInt e) = ethEnvFromExp e
+ethEnvFromReturnExp (ExpBool e) = ethEnvFromExp e
+ethEnvFromReturnExp (ExpBytes e) = ethEnvFromExp e
+
+ethEnvFromExp :: Exp a -> [EthEnv]
+ethEnvFromExp e = case e of
+  And a b   -> ethEnvFromExp a <> ethEnvFromExp b
+  Or a b    -> ethEnvFromExp a <> ethEnvFromExp b
+  Impl a b  -> ethEnvFromExp a <> ethEnvFromExp b
+  Eq a b    -> ethEnvFromExp a <> ethEnvFromExp b
+  LE a b    -> ethEnvFromExp a <> ethEnvFromExp b
+  LEQ a b   -> ethEnvFromExp a <> ethEnvFromExp b
+  GE a b    -> ethEnvFromExp a <> ethEnvFromExp b
+  GEQ a b   -> ethEnvFromExp a <> ethEnvFromExp b
+  NEq a b   -> ethEnvFromExp a <> ethEnvFromExp b
+  Neg a     -> ethEnvFromExp a
+  Add a b   -> ethEnvFromExp a <> ethEnvFromExp b
+  Sub a b   -> ethEnvFromExp a <> ethEnvFromExp b
+  Mul a b   -> ethEnvFromExp a <> ethEnvFromExp b
+  Div a b   -> ethEnvFromExp a <> ethEnvFromExp b
+  Mod a b   -> ethEnvFromExp a <> ethEnvFromExp b
+  Exp a b   -> ethEnvFromExp a <> ethEnvFromExp b
+  Cat a b   -> ethEnvFromExp a <> ethEnvFromExp b
+  Slice a b c -> ethEnvFromExp a <> ethEnvFromExp b <> ethEnvFromExp c
+  ITE a b c -> ethEnvFromExp a <> ethEnvFromExp b <> ethEnvFromExp c
+  ByVar _ -> []
+  ByStr _ -> []
+  ByLit _ -> []
+  LitInt _  -> []
+  IntVar _  -> []
+  LitBool _ -> []
+  BoolVar _ -> []
+  IntMin _ -> []
+  IntMax _ -> []
+  UIntMin _ -> []
+  UIntMax _ -> []
+  NewAddr a b -> ethEnvFromExp a <> ethEnvFromExp b
+  IntEnv a -> [a]
+  ByEnv a -> [a]
+  TEntry a  -> ethEnvFromItem a
+
+getLoc :: Either StorageLocation StorageUpdate -> StorageLocation
+getLoc = either id mkLoc
+
+mkLoc :: StorageUpdate -> StorageLocation
+mkLoc (IntUpdate item _) = IntLoc item
+mkLoc (BoolUpdate item _) = BoolLoc item
+mkLoc (BytesUpdate item _) = BytesLoc item
+
+nameFromStorage :: Syntax.Storage -> Id
+nameFromStorage (Rewrite (Entry _ name _) _) = name
+nameFromStorage (Constant (Entry _ name _)) = name
+nameFromStorage store = error $ "Internal error: cannot extract name from " ++ (show store)
+
+getId :: Either StorageLocation StorageUpdate -> Id
+getId (Right (IntUpdate a _)) = getId' a
+getId (Right (BoolUpdate a _)) = getId' a
+getId (Right (BytesUpdate a _)) = getId' a
+getId (Left (IntLoc a)) = getId' a
+getId (Left (BoolLoc a)) = getId' a
+getId (Left (BytesLoc a)) = getId' a
+
+getId' :: TStorageItem a -> Id
+getId' (DirectInt _ name) = name
+getId' (DirectBool _ name) = name
+getId' (DirectBytes _ name) = name
+getId' (MappedInt _ name _) = name
+getId' (MappedBool _ name _) = name
+getId' (MappedBytes _ name _) = name
+
+getContract :: Either StorageLocation StorageUpdate -> Id
+getContract (Left (IntLoc item)) = getContract' item
+getContract (Left (BoolLoc item)) = getContract' item
+getContract (Left (BytesLoc item)) = getContract' item
+getContract (Right (IntUpdate item _)) = getContract' item
+getContract (Right (BoolUpdate item _)) = getContract' item
+getContract (Right (BytesUpdate item _)) = getContract' item
+
+getContract' :: TStorageItem a -> Id
+getContract' (DirectInt c _) = c
+getContract' (DirectBool c _) = c
+getContract' (DirectBytes c _) = c
+getContract' (MappedInt c _ _) = c
+getContract' (MappedBool c _ _) = c
+getContract' (MappedBytes c _ _) = c
+
+contractsInvolved :: Behaviour -> [Id]
+contractsInvolved beh =
+  getContractId . getLoc <$> _stateUpdates beh
+
+getContractId :: StorageLocation -> Id
+getContractId (IntLoc (DirectInt a _)) = a
+getContractId (BoolLoc (DirectBool a _)) = a
+getContractId (BytesLoc (DirectBytes a _)) = a
+getContractId (IntLoc (MappedInt a _ _)) = a
+getContractId (BoolLoc (MappedBool a _ _)) = a
+getContractId (BytesLoc (MappedBytes a _ _)) = a
+
+getContainerId :: StorageLocation -> Id
+getContainerId (IntLoc (DirectInt _ a)) = a
+getContainerId (BoolLoc (DirectBool _ a)) = a
+getContainerId (BytesLoc (DirectBytes _ a)) = a
+getContainerId (IntLoc (MappedInt _ a _)) = a
+getContainerId (BoolLoc (MappedBool _ a _)) = a
+getContainerId (BytesLoc (MappedBytes _ a _)) = a
+
+getContainerIxs :: StorageLocation -> [ReturnExp]
+getContainerIxs (IntLoc (DirectInt _ _)) = []
+getContainerIxs (BoolLoc (DirectBool _ _)) = []
+getContainerIxs (BytesLoc (DirectBytes _ _)) = []
+getContainerIxs (IntLoc (MappedInt _ _ ixs)) = NonEmpty.toList ixs
+getContainerIxs (BoolLoc (MappedBool _ _ ixs)) = NonEmpty.toList ixs
+getContainerIxs (BytesLoc (MappedBytes _ _ ixs)) = NonEmpty.toList ixs

--- a/src/HEVM.hs
+++ b/src/HEVM.hs
@@ -1,14 +1,15 @@
 {-# Language RecordWildCards #-}
-{-# Language LambdaCase #-}
 {-# Language TypeApplications #-}
 {-# Language OverloadedStrings #-}
 {-# Language DataKinds #-}
 {-# Language GADTs #-}
+
 module HEVM where
 
 import Prelude hiding (lookup)
 import Syntax
 import RefinedAst hiding (S)
+import Extract
 
 import Data.Text (Text, pack, splitOn)
 import Data.Maybe
@@ -62,7 +63,7 @@ proveBehaviour sources behaviour = do
 
      postC (pre, post) = mkPostCondition pre post sources' behaviour contractMap (ctx pre post)
 
-    
+
 interfaceCalldata :: Interface -> Symbolic Buffer
 interfaceCalldata (Interface methodname vars) =
   let types = fmap (\(Decl typ _) -> typ) vars
@@ -209,7 +210,7 @@ locateStorage ctx solcjson contractMap method (pre, post) item =
 
   in (name item',  (SymInteger (sFromIntegral preValue), SymInteger (sFromIntegral postValue)))
 
--- | 
+-- |
 calculateSlot :: Ctx -> SolcJson -> StorageLocation -> SymWord
 calculateSlot ctx solcjson loc =
   -- TODO: packing with offset

--- a/src/K.hs
+++ b/src/K.hs
@@ -9,6 +9,7 @@ module K where
 
 import Syntax
 import RefinedAst
+import Extract
 import ErrM
 import Data.Text (Text, pack, unpack)
 import Data.Type.Equality
@@ -80,42 +81,6 @@ kCalldata (Interface a b) =
        args ->
          intercalate ", " (fmap (\(Decl typ varname) -> "#" <> show typ <> "(" <> kVar varname <> ")") args))
   <> ")"
-
-getId :: Either StorageLocation StorageUpdate -> Id
-getId (Right (IntUpdate a _)) = getId' a
-getId (Right (BoolUpdate a _)) = getId' a
-getId (Right (BytesUpdate a _)) = getId' a
-getId (Left (IntLoc a)) = getId' a
-getId (Left (BoolLoc a)) = getId' a
-getId (Left (BytesLoc a)) = getId' a
-
-getId' :: TStorageItem a -> Id
-getId' (DirectInt _ name) = name
-getId' (DirectBool _ name) = name
-getId' (DirectBytes _ name) = name
-getId' (MappedInt _ name _) = name
-getId' (MappedBool _ name _) = name
-getId' (MappedBytes _ name _) = name
-
-getContract :: Either StorageLocation StorageUpdate -> Id
-getContract (Left (IntLoc item)) = getContract' item
-getContract (Left (BoolLoc item)) = getContract' item
-getContract (Left (BytesLoc item)) = getContract' item
-getContract (Right (IntUpdate item _)) = getContract' item
-getContract (Right (BoolUpdate item _)) = getContract' item
-getContract (Right (BytesUpdate item _)) = getContract' item
-
-getContract' :: TStorageItem a -> Id
-getContract' (DirectInt c _) = c
-getContract' (DirectBool c _) = c
-getContract' (DirectBytes c _) = c
-getContract' (MappedInt c _ _) = c
-getContract' (MappedBool c _ _) = c
-getContract' (MappedBytes c _ _) = c
-
-conjunction :: [Invariant] -> Exp Bool
-conjunction [] = LitBool True
-conjunction ((Invariant _ e):tl) = And e (conjunction tl)
 
 kStorageName :: TStorageItem a -> String
 kStorageName (DirectInt _ name)    = kVar name

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -99,7 +99,7 @@ main = do
         contents <- readFile file'
         proceed contents (compile contents) $ \claims -> do
             let
-                handleResults ((Invariant c e), rs) = do
+                handleResults ((Invariant c _ e), rs) = do
                   let msg = "\n============\n\nInvariant " <> show (prettyExp e) <> " of " <> show c <> ": "
                       sep = "\n\n---\n\n"
                       results' = handleRes <$> rs

--- a/src/RefinedAst.hs
+++ b/src/RefinedAst.hs
@@ -33,7 +33,11 @@ data Claim = C Constructor | B Behaviour | I Invariant | S Store deriving (Show,
 
 type Store = Map Id (Map Id SlotType)
 
-data Invariant = Invariant Id (Exp Bool) deriving (Show, Eq)
+data Invariant = Invariant
+  { _icontract :: Id
+  , _ipreconditions :: [Exp Bool]
+  , _predicate :: Exp Bool
+  } deriving (Show, Eq)
 
 data Constructor = Constructor
   { _cname :: Id,
@@ -54,8 +58,7 @@ data Behaviour = Behaviour
    _postconditions :: [Exp Bool],
    _stateUpdates :: [Either StorageLocation StorageUpdate],
    _returns :: Maybe ReturnExp
-  }
-  deriving (Show, Eq)
+  } deriving (Show, Eq)
 
 data Mode
   = Pass
@@ -203,9 +206,10 @@ data ReturnExp
 instance ToJSON Claim where
   toJSON (S storages) = object [ "kind" .= (String "Storages")
                                           , "storages" .= toJSON storages]
-  toJSON (I (Invariant contract e)) = object [ "kind" .= (String "Invariant")
-                                             , "expression" .= toJSON e
-                                             , "contract" .= show contract ]
+  toJSON (I (Invariant {..})) = object [ "kind" .= (String "Invariant")
+                                       , "predicate" .= toJSON _predicate
+                                       , "preconditions" .= toJSON _ipreconditions
+                                       , "contract" .= _icontract]
   toJSON (C (Constructor {..})) = object  [ "kind" .= (String "Constructor")
                                           , "contract" .= _cname
                                           , "mode" .= (String . pack $ show _cmode)

--- a/src/act.cabal
+++ b/src/act.cabal
@@ -20,7 +20,7 @@ common deps
                  mtl              >= 2.2.2,
                  utf8-string      >= 1.0.1.1
   ghc-options:   -Wall -Wno-deprecations
-  other-modules: Lex ErrM Parse RefinedAst K HEVM Coq Syntax Type Prove Print Enrich
+  other-modules: Lex ErrM Extract Parse RefinedAst K HEVM Coq Syntax Type Prove Print Enrich
 
 executable act
   import:             deps

--- a/tests/frontend/pass/creation/create.act.typed.json
+++ b/tests/frontend/pass/creation/create.act.typed.json
@@ -14,8 +14,9 @@
   },
   {
     "kind": "Invariant",
-    "contract": "\"Modest\"",
-    "expression": "True"
+    "predicate": "True",
+    "preconditions": [],
+    "contract": "Modest"
   },
   {
     "kind": "Constructor",

--- a/tests/frontend/pass/multi/multi.act.typed.json
+++ b/tests/frontend/pass/multi/multi.act.typed.json
@@ -16,13 +16,15 @@
   },
   {
     "kind": "Invariant",
-    "contract": "\"a\"",
-    "expression": "True"
+    "predicate": "True",
+    "preconditions": [],
+    "contract": "a"
   },
   {
     "kind": "Invariant",
-    "contract": "\"B\"",
-    "expression": "True"
+    "predicate": "True",
+    "preconditions": [],
+    "contract": "B"
   },
   {
     "kind": "Constructor",

--- a/tests/frontend/pass/token/transfer.act.typed.json
+++ b/tests/frontend/pass/token/transfer.act.typed.json
@@ -27,8 +27,7 @@
   },
   {
     "kind": "Invariant",
-    "contract": "\"Token\"",
-    "expression": {
+    "predicate": {
       "arity": 2,
       "args": [
         {
@@ -38,31 +37,132 @@
         "_totalSupply"
       ],
       "symbol": "=="
-    }
+    },
+    "preconditions": [
+      {
+        "arity": 2,
+        "args": [
+          {
+            "arity": 2,
+            "args": [
+              "0",
+              "_totalSupply"
+            ],
+            "symbol": "<="
+          },
+          {
+            "arity": 2,
+            "args": [
+              "_totalSupply",
+              "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+            ],
+            "symbol": "<="
+          }
+        ],
+        "symbol": "and"
+      },
+      {
+        "arity": 2,
+        "args": [
+          {
+            "arity": 2,
+            "args": [
+              "0",
+              {
+                "name": "Token.totalSupply",
+                "sort": "int"
+              }
+            ],
+            "symbol": "<="
+          },
+          {
+            "arity": 2,
+            "args": [
+              {
+                "name": "Token.totalSupply",
+                "sort": "int"
+              },
+              "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+            ],
+            "symbol": "<="
+          }
+        ],
+        "symbol": "and"
+      }
+    ],
+    "contract": "Token"
   },
   {
     "kind": "Invariant",
-    "contract": "\"Token\"",
-    "expression": {
+    "predicate": {
       "arity": 2,
       "args": [
         "TEntry (DirectBytes \"Token\" \"name\")",
         "ByVar \"_name\""
       ],
       "symbol": "=="
-    }
+    },
+    "preconditions": [
+      {
+        "arity": 2,
+        "args": [
+          {
+            "arity": 2,
+            "args": [
+              "0",
+              "_totalSupply"
+            ],
+            "symbol": "<="
+          },
+          {
+            "arity": 2,
+            "args": [
+              "_totalSupply",
+              "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+            ],
+            "symbol": "<="
+          }
+        ],
+        "symbol": "and"
+      }
+    ],
+    "contract": "Token"
   },
   {
     "kind": "Invariant",
-    "contract": "\"Token\"",
-    "expression": {
+    "predicate": {
       "arity": 2,
       "args": [
         "TEntry (DirectBytes \"Token\" \"symbol\")",
         "ByVar \"_symbol\""
       ],
       "symbol": "=="
-    }
+    },
+    "preconditions": [
+      {
+        "arity": 2,
+        "args": [
+          {
+            "arity": 2,
+            "args": [
+              "0",
+              "_totalSupply"
+            ],
+            "symbol": "<="
+          },
+          {
+            "arity": 2,
+            "args": [
+              "_totalSupply",
+              "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+            ],
+            "symbol": "<="
+          }
+        ],
+        "symbol": "and"
+      }
+    ],
+    "contract": "Token"
   },
   {
     "kind": "Constructor",


### PR DESCRIPTION
Two major changes:

- Pull logic for adding constraints on the size of variables referenced by the invariant expressions into Enrich.hs
- Add a new module (Extract) that contains all logic used to extract information from the AST

This also fixes a bug where type bounds for calldata / env vars referenced in the invariant were missing.