### PR TITLE
Enfore build cleanliness

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -12,9 +12,10 @@ let
       hevm = dapptools.haskellPackages.hevm;
       sbv = dapptools.haskellPackages.sbv;
       act =
-        hself.callCabal2nix
+        hself.callCabal2nixWithOptions
           "act"
           (gitignore ./src)
+          "-fci"
           {};
     };
   };

--- a/src/act.cabal
+++ b/src/act.cabal
@@ -26,9 +26,9 @@ common deps
                  utf8-string      >= 1.0.1.1
   other-modules: Lex ErrM Extract Parse RefinedAst K HEVM Coq Syntax Type Prove Print Enrich
   if flag(ci)
-      ghc-options: -O2 -Wall -Werror -Wno-deprecations -Wno-orphans
+      ghc-options: -O2 -Wall -Werror -Wno-orphans
   else
-      ghc-options: -Wall -Wno-deprecations -Wno-orphans
+      ghc-options: -Wall -Wno-orphans
 
 executable act
   import:             deps

--- a/src/act.cabal
+++ b/src/act.cabal
@@ -5,6 +5,11 @@ version:    0.1.0.0
 author:     Martin Lundfall
 maintainer: martin.lundfall@protonmail.com
 
+flag ci
+    description: Sets flags for compilation in CI
+    default:     False
+    manual:      True
+
 common deps
   build-depends: base             >= 4.9 && < 5,
                  aeson            >= 1.0,
@@ -19,8 +24,11 @@ common deps
                  sbv              >= 8.4,
                  mtl              >= 2.2.2,
                  utf8-string      >= 1.0.1.1
-  ghc-options:   -Wall -Wno-deprecations
   other-modules: Lex ErrM Extract Parse RefinedAst K HEVM Coq Syntax Type Prove Print Enrich
+  if flag(ci)
+      ghc-options: -O2 -Wall -Werror -Wno-deprecations -Wno-orphans
+  else
+      ghc-options: -Wall -Wno-deprecations -Wno-orphans
 
 executable act
   import:             deps


### PR DESCRIPTION
This PR adds a `ci` flag to the build system that:

- forces all warnings to be errors
- enables the optimizer (`-O2`)

The `ci` flag is enabled for all `nix` builds.

Local builds (`cabal v2-build`) will still succeed in the prescense of warnings (although the same set of warnings will be shown in both configs).

We currently ignore the following compiler warnings in both configurations:

- orphan instances
- ~deprecated~

This is built on top of #89, I'll retarget to master once it's merged.