### PR TITLE
Type: rm implicit invariant hack...

### DIFF
--- a/src/Type.hs
+++ b/src/Type.hs
@@ -142,14 +142,11 @@ splitBehaviour store (Definition contract iface@(Interface _ decls) iffs (Create
   invariants <- mapM (\expr -> checkBool (getPosn expr) env expr) $ fromMaybe [] maybeInvs
   ensures <- mapM (\expr -> checkBool (getPosn expr) env expr) (fromMaybe [] maybeEnsures)
 
-  -- this forces the smt backend to be run on every spec, ensuring postconditions are checked for every behaviour
-  -- TODO: seperate the smt backend into seperate passes so we only run the invariant analysis if required
-  let invariants' = if (null invariants) then [LitBool True] else invariants
-      cases' = if null iffs' then [C $ Constructor contract Pass iface iffs' ensures stateUpdates []]
+  let cases' = if null iffs' then [C $ Constructor contract Pass iface iffs' ensures stateUpdates []]
                else [ C $ Constructor contract Pass iface iffs' ensures stateUpdates []
                        , C $ Constructor contract Fail iface [Neg (mconcat iffs')] ensures [] []]
 
-  return $ ((I . (Invariant contract [] [])) <$> invariants')
+  return $ ((I . (Invariant contract [] [])) <$> invariants)
            <> cases'
 
 mkEnv :: Id -> Store -> [Decl]-> Env

--- a/tests/frontend/pass/creation/create.act.typed.json
+++ b/tests/frontend/pass/creation/create.act.typed.json
@@ -13,13 +13,6 @@
     "kind": "Storages"
   },
   {
-    "kind": "Invariant",
-    "predicate": "True",
-    "preconditions": [],
-    "contract": "Modest",
-    "storagebounds": []
-  },
-  {
     "kind": "Constructor",
     "mode": "Pass",
     "storage": [

--- a/tests/frontend/pass/multi/multi.act.typed.json
+++ b/tests/frontend/pass/multi/multi.act.typed.json
@@ -15,20 +15,6 @@
     "kind": "Storages"
   },
   {
-    "kind": "Invariant",
-    "predicate": "True",
-    "preconditions": [],
-    "contract": "a",
-    "storagebounds": []
-  },
-  {
-    "kind": "Invariant",
-    "predicate": "True",
-    "preconditions": [],
-    "contract": "B",
-    "storagebounds": []
-  },
-  {
     "kind": "Constructor",
     "mode": "Pass",
     "storage": [


### PR DESCRIPTION
Forgot to do this in the last pr, it's no longer needed since we have properly seperated analysis stages with the new backend.