### PR TITLE
Prevent storage read in `creates` block

### DIFF
--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Syntax where
-import Data.List (intercalate)
+import Data.List (intercalate,nub)
 import EVM.ABI (AbiType)
 import EVM.Solidity (SlotType)
 import Lex
@@ -166,3 +166,37 @@ getPosn expr = case expr of
     IntLit pn _ -> pn
     BoolLit pn _ -> pn
 
+getIds :: Expr -> [Id]
+getIds e = nub $ case e of
+  EAnd _ a b        -> getIds a <> getIds b
+  EOr _ a b         -> getIds a <> getIds b
+  ENot _ a          -> getIds a
+  EImpl _ a b       -> getIds a <> getIds b
+  EEq _ a b         -> getIds a <> getIds b
+  ENeq _ a b        -> getIds a <> getIds b
+  ELEQ _ a b        -> getIds a <> getIds b
+  ELT _ a b         -> getIds a <> getIds b
+  EGEQ _ a b        -> getIds a <> getIds b
+  EGT _ a b         -> getIds a <> getIds b
+  EAdd _ a b        -> getIds a <> getIds b
+  ESub _ a b        -> getIds a <> getIds b
+  EITE _ a b c      -> getIds a <> getIds b <> getIds c
+  EMul _ a b        -> getIds a <> getIds b
+  EDiv _ a b        -> getIds a <> getIds b
+  EMod _ a b        -> getIds a <> getIds b
+  EExp _ a b        -> getIds a <> getIds b
+  Zoom _ a b        -> getIds a <> getIds b
+  EntryExp _ x _    -> [x]
+  Func _ _ a        -> getIds =<< a
+  ListConst a       -> getIds a
+  ECat _ a b        -> getIds a <> getIds b
+  ESlice _ a b c    -> getIds a <> getIds b <> getIds c
+  ENewaddr _ a b    -> getIds a <> getIds b
+  ENewaddr2 _ a b c -> getIds a <> getIds b <> getIds c
+  BYHash _ a        -> getIds a
+  BYAbiE _ a        -> getIds a
+  StringLit {}      -> []
+  WildExp {}        -> []
+  EnvExp {}         -> []
+  IntLit {}         -> []
+  BoolLit {}        -> []

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -166,7 +166,7 @@ getPosn expr = case expr of
     IntLit pn _ -> pn
     BoolLit pn _ -> pn
 
-getIds :: Expr -> [Id]
+getIds :: Expr -> [(Id,Pn)]
 getIds e = nub $ case e of
   EAnd _ a b        -> getIds a <> getIds b
   EOr _ a b         -> getIds a <> getIds b
@@ -186,8 +186,8 @@ getIds e = nub $ case e of
   EMod _ a b        -> getIds a <> getIds b
   EExp _ a b        -> getIds a <> getIds b
   Zoom _ a b        -> getIds a <> getIds b
-  EntryExp _ x _    -> [x]
-  Func _ _ a        -> getIds =<< a
+  EntryExp p x es   -> (x,p)    :  (getIds =<< es)
+  Func _ _ es       -> getIds =<< es
   ListConst a       -> getIds a
   ECat _ a b        -> getIds a <> getIds b
   ESlice _ a b c    -> getIds a <> getIds b <> getIds c

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -168,8 +168,6 @@ noStorageRead store e = forM_ (getIds e) $ \(name,pos) ->
   if member name store
     then Bad (pos,"Cannot read from storage in creates block")
     else Ok ()
--- | all (flip notMember store) (getIds e) = Ok ()
---                       | otherwise = Bad (getPosn e, "Cannot read from storage in creates block")
 
 -- ensures that key types match value types in an Assign
 checkAssign :: Env -> Assign -> Err [StorageUpdate]

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -10,7 +10,7 @@ module Type (typecheck, bound, lookupVars, defaultStore, metaType) where
 import Data.List
 import EVM.ABI
 import EVM.Solidity (SlotType(..))
-import Data.Map.Strict    (Map)
+import Data.Map.Strict    (Map,notMember)
 import Data.Maybe
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NonEmpty
@@ -163,10 +163,15 @@ splitCase name contract iface if' iffs ret storage postcs =
   [ B $ Behaviour name Pass contract iface (if' <> iffs) postcs storage ret,
     B $ Behaviour name Fail contract iface (if' <> [Neg (mconcat iffs)]) [] (Left . getLoc <$> storage) Nothing ]
 
+noStorageRead :: Map Id SlotType -> Expr -> Err ()
+noStorageRead store e | all (flip notMember store) (getIds e) = Ok ()
+                      | otherwise = Bad (getPosn e, "Cannot read from storage in creates block")
+
 -- ensures that key types match value types in an Assign
 checkAssign :: Env -> Assign -> Err [StorageUpdate]
-checkAssign env@(contract, _, _, _) (AssignVal (StorageVar (StorageValue typ) name) expr)
-  = case metaType typ of
+checkAssign env@(contract, store, _, _) (AssignVal (StorageVar (StorageValue typ) name) expr)
+  = noStorageRead store expr >>
+  case metaType typ of
     Integer -> do
       val <- checkInt (getPosn expr) env expr
       return [IntUpdate (DirectInt contract name) val]
@@ -176,8 +181,10 @@ checkAssign env@(contract, _, _, _) (AssignVal (StorageVar (StorageValue typ) na
     ByteStr -> do
       val <- checkBytes (getPosn expr) env expr
       return [BytesUpdate (DirectBytes contract name) val]
-checkAssign env (AssignMany (StorageVar (StorageMapping (keyType :| _) valType) name) defns)
-  = mapM (checkDefn env keyType valType name) defns
+checkAssign env@(_, store, _, _) (AssignMany (StorageVar (StorageMapping (keyType :| _) valType) name) defns)
+  = do
+      mapM_ (\(Defn e1 e2) -> mapM_ (noStorageRead store) [e1,e2]) defns
+      mapM (checkDefn env keyType valType name) defns
 checkAssign _ (AssignVal (StorageVar (StorageMapping _ _) _) expr)
   = Bad (getPosn expr, "Cannot assign a single expression to a composite type")
 checkAssign _ (AssignMany (StorageVar (StorageValue _) _) _)

--- a/tests/frontend/fail/emptystorage/circular.act
+++ b/tests/frontend/fail/emptystorage/circular.act
@@ -1,0 +1,7 @@
+constructor of LValue
+interface constructor()
+
+creates
+
+    uint x := y
+    uint y := x

--- a/tests/frontend/fail/emptystorage/mapkey.act
+++ b/tests/frontend/fail/emptystorage/mapkey.act
@@ -1,0 +1,7 @@
+constructor of ReadMappingIndex
+interface constructor(uint _x, uint _y)
+
+creates
+  uint                x := _x
+  uint                y := _y
+  mapping(uint=>uint) m := [x := _y]

--- a/tests/frontend/fail/emptystorage/mapkeyexp.act
+++ b/tests/frontend/fail/emptystorage/mapkeyexp.act
@@ -1,0 +1,7 @@
+constructor of ReadMappingIndex
+interface constructor(uint _x, uint _y)
+
+creates
+  uint                x := _x
+  uint                y := _y
+  mapping(uint=>uint) m := [x + 5 := _y]

--- a/tests/frontend/fail/emptystorage/mapval.act
+++ b/tests/frontend/fail/emptystorage/mapval.act
@@ -1,0 +1,7 @@
+constructor of ReadMapping
+interface constructor(uint _x, uint _y)
+
+creates
+  uint                x := _x
+  uint                y := _y
+  mapping(uint=>uint) m := [_x := y]

--- a/tests/frontend/fail/emptystorage/mapvalexp.act
+++ b/tests/frontend/fail/emptystorage/mapvalexp.act
@@ -1,0 +1,7 @@
+constructor of ReadMapping
+interface constructor(uint _x, uint _y)
+
+creates
+  uint                x := _x
+  uint                y := _y
+  mapping(uint=>uint) m := [_x := y + 5]

--- a/tests/frontend/fail/emptystorage/var.act
+++ b/tests/frontend/fail/emptystorage/var.act
@@ -1,0 +1,10 @@
+constructor of LValue
+interface constructor()
+
+creates
+
+    uint x := (true && x)
+    
+invariants
+
+    x == 0

--- a/tests/frontend/fail/emptystorage/varexp.act
+++ b/tests/frontend/fail/emptystorage/varexp.act
@@ -1,0 +1,10 @@
+constructor of LValue
+interface constructor()
+
+creates
+
+    uint x := true and x
+    
+invariants
+
+    x == 0


### PR DESCRIPTION
Closes #71 

One issue I can currently see is with the following test:

```
constructor of LValue
interface constructor()

creates

    uint x := y
    uint y := x
```

This does fail to typecheck, but unfortunately only with one error instead of two:

```
6 |     uint x := y
                  ^
Cannot read storage in creates block
```

This is because of the way the `Err` monad works. Maybe it is more designed for parsing than for type checking? Regardless this doesn't seem like it's covered by the issue I'm trying to solve here, but I guess it's worthwhile to consider while you're looking at error handling @xwvvvvwx?