### PR TITLE
Simplify exponentiation in SMT backend

### DIFF
--- a/src/RefinedAst.hs
+++ b/src/RefinedAst.hs
@@ -16,6 +16,7 @@ module RefinedAst where
 
 import Control.Applicative (empty)
 
+import Data.List (genericDrop,genericTake)
 import Data.Text (pack)
 import Data.Type.Equality
 import Data.Typeable
@@ -250,9 +251,10 @@ eval e = case e of
   UIntMax a   -> pure $ 2 ^ a - 1
 
   Cat s t     -> [s' <> t' | s' <- eval s, t' <- eval t]
-  Slice s a b -> [BS.drop a' . BS.take b' $ s' | s' <- eval s
-                                               , a' <- fromInteger <$> eval a
-                                               , b' <- fromInteger <$> eval b]
+  Slice s a b -> [BS.pack . genericDrop a' . genericTake b' $ s'
+                           | s' <- BS.unpack <$> eval s
+                           , a' <- eval a
+                           , b' <- eval b]
   ByVar _     -> empty
   ByStr s     -> pure . fromString $ s
   ByLit s     -> pure s

--- a/src/SMT.hs
+++ b/src/SMT.hs
@@ -410,9 +410,9 @@ expToSMT2 ctx@(Ctx behvName whn) e = case e of
 -- | SMT2 has no support for exponentiation, but we can do some preprocessing
 --   if the RHS is concrete to provide some limited support for exponentiation
 simplifyExponentiation :: Exp Integer -> Exp Integer -> Exp Integer
-simplifyExponentiation a b = fromMaybe (error "Internal Error: exponentiation is unsupported in SMT lib")
-                           $   [LitInt $ a' ^ b'                      | a' <- eval a,   b' <- evalb]
-                           <|> [foldr Mul (LitInt 1) (replicate b' a) | b' <- fromInteger <$> evalb]
+simplifyExponentiation a b = fromMaybe (error "Internal Error: no support for symbolic exponents in SMT lib")
+                             $   [LitInt $ a' ^ b'                      | a' <- eval a,   b' <- evalb]
+                             <|> [foldr Mul (LitInt 1) (replicate b' a) | b' <- fromInteger <$> evalb]
   where
     evalb = eval b
 

--- a/src/SMT.hs
+++ b/src/SMT.hs
@@ -411,8 +411,8 @@ expToSMT2 ctx@(Ctx behvName whn) e = case e of
 --   if the RHS is concrete to provide some limited support for exponentiation
 simplifyExponentiation :: Exp Integer -> Exp Integer -> Exp Integer
 simplifyExponentiation a b = fromMaybe (error "Internal Error: no support for symbolic exponents in SMT lib")
-                             $   [LitInt $ a' ^ b'                      | a' <- eval a,   b' <- evalb]
-                             <|> [foldr Mul (LitInt 1) (replicate b' a) | b' <- fromInteger <$> evalb]
+                             $   [LitInt $ a' ^ b'               | a' <- eval a, b' <- evalb]
+                             <|> [foldr Mul (LitInt 1) (genericReplicate b' a) | b' <- evalb]
   where
     evalb = eval b
 

--- a/tests/invariants/fail/concretebase.act
+++ b/tests/invariants/fail/concretebase.act
@@ -1,0 +1,10 @@
+constructor of Exponentiation
+interface constructor()
+
+creates
+
+    uint256 thirtytwo := (10 - 2 * 4) ^ (100 - 5 * 19)
+
+invariants
+
+    thirtytwo == 33

--- a/tests/invariants/fail/concreteexponent.act
+++ b/tests/invariants/fail/concreteexponent.act
@@ -1,0 +1,10 @@
+constructor of Exponentiation
+interface constructor(uint256 x)
+
+creates
+
+    uint256 xpow5 := x ^ (100 - 5 * 19)
+
+invariants
+
+    xpow5 == x ^ 4

--- a/tests/invariants/fail/symbolicexponent.act
+++ b/tests/invariants/fail/symbolicexponent.act
@@ -1,0 +1,10 @@
+constructor of Exponentiation
+interface constructor(uint x)
+
+creates
+
+    uint256 exponential := (10 - 2 * 4) ^ (100 - x * 19)
+
+invariants
+
+    exponential == 32

--- a/tests/invariants/pass/concretebase.act
+++ b/tests/invariants/pass/concretebase.act
@@ -1,0 +1,10 @@
+constructor of Exponentiation
+interface constructor()
+
+creates
+
+    uint256 thirtytwo := (10 - 2 * 4) ^ (100 - 5 * 19)
+
+invariants
+
+    thirtytwo == 32

--- a/tests/invariants/pass/concreteexponent.act
+++ b/tests/invariants/pass/concreteexponent.act
@@ -1,0 +1,10 @@
+constructor of Exponentiation
+interface constructor(uint256 x)
+
+creates
+
+    uint256 xpow5 := x ^ (100 - 5 * 19)
+
+invariants
+
+    xpow5 == x ^ 5


### PR DESCRIPTION
Closes #99, i.e. we can now pass any exponentiation where the exponent is concrete to the SMT backend even though it has no support for exponentiation. This does not however include any algebraic analysis to attempt to simplify away symbolic values.

I'm a bit uncertain on how division is to be dealt with. Currently I'm using `div` and `mod` from Haskell's Prelude (rather than `quot` and `rem`). This is because they truncate towards negative infinity, which is what the EVM seems to be doing according to the yellow paper. But what exactly are we trying to agree with? The EVM? In that case `x/0` should be `0`, so we need a special case for that. Or Solidity? Or our other backends?