### PR TITLE
represent bytes32 as an int internally

### DIFF
--- a/src/Extract.hs
+++ b/src/Extract.hs
@@ -172,7 +172,7 @@ metaType (AbiUIntType _)     = Integer
 metaType (AbiIntType  _)     = Integer
 metaType AbiAddressType      = Integer
 metaType AbiBoolType         = Boolean
-metaType (AbiBytesType _)    = ByteStr
+metaType (AbiBytesType n)    = if n <= 32 then Integer else ByteStr
 metaType AbiBytesDynamicType = ByteStr
 metaType AbiStringType       = ByteStr
 --metaType (AbiArrayDynamicType a) =

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -69,7 +69,7 @@ defaultStore :: [(EthEnv, MType)]
 defaultStore =
   [(Callvalue, Integer),
    (Caller, Integer),
-   (Blockhash, ByteStr),
+   (Blockhash, Integer),
    (Blocknumber, Integer),
    (Difficulty, Integer),
    (Timestamp, Integer),
@@ -168,7 +168,7 @@ noStorageRead :: Map Id SlotType -> Expr -> Err ()
 noStorageRead store expr = forM_ (keys store) $ \name ->
   forM_ (findWithDefault [] name (getIds expr)) $ \pn ->
     Bad (pn,"Cannot read storage in creates block")
-  
+
 -- ensures that key types match value types in an Assign
 checkAssign :: Env -> Assign -> Err [StorageUpdate]
 checkAssign env@(contract, store, _, _) (AssignVal (StorageVar (StorageValue typ) name) expr)
@@ -325,6 +325,7 @@ upperBound :: AbiType -> Exp Integer
 upperBound (AbiUIntType n) = UIntMax n
 upperBound (AbiIntType n) = IntMax n
 upperBound AbiAddressType = UIntMax 160
+upperBound (AbiBytesType n) = UIntMax (8 * n)
 upperBound typ  = error $ "upperBound not implemented for " ++ show typ
 
 

--- a/src/test/Test.hs
+++ b/src/test/Test.hs
@@ -141,7 +141,7 @@ genType typ = case typ of
                    , AbiBytesType <$> validBytesSize
                    ]
   Boolean -> return AbiBoolType
-  ByteStr -> oneof [ return AbiStringType ]
+  ByteStr -> return AbiStringType
                    --, return AbiBytesDynamicType -- TODO: needs frontend support
 
   where
@@ -159,8 +159,7 @@ genReturnExp names n = oneof
 
 -- TODO: literals, cat slice, ITE, storage, ByStr
 genExpBytes :: Names -> Int -> ExpoGen (Exp ByteString)
-genExpBytes names _ = oneof
-  [ ByVar <$> (selectName ByteStr names) ]
+genExpBytes names _ = ByVar <$> selectName ByteStr names
 
 -- TODO: ITE, storage
 genExpBool :: Names -> Int -> ExpoGen (Exp Bool)

--- a/tests/invariants/fail/ethEnv.act
+++ b/tests/invariants/fail/ethEnv.act
@@ -21,7 +21,7 @@ invariants
     this == THIS
     value == CALLVALUE
     depth == CALLDEPTH
-    // hash == BLOCKHASH
+    hash == BLOCKHASH
     number == BLOCKNUMBER
     difficulty == DIFFICULTY
     chainid == CHAINID
@@ -45,4 +45,4 @@ storage
     coinbase => 1
     timestamp => 1
     nonce => 1
-    // hash => (hash ++ BLOCKHASH)
+    hash => 1

--- a/tests/invariants/pass/ethEnv.act
+++ b/tests/invariants/pass/ethEnv.act
@@ -21,7 +21,7 @@ invariants
     this == THIS
     value == CALLVALUE
     depth == CALLDEPTH
-    // hash == BLOCKHASH
+    hash == BLOCKHASH
     number == BLOCKNUMBER
     difficulty == DIFFICULTY
     chainid == CHAINID


### PR DESCRIPTION
bytestrings are not well supported in act at the moment so this lets us verify contracts involving `bytes32` in hevm and Coq, and it should anyway be a nice optimisation.