### PR TITLE
bump dapptools

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://dapp.tools",
         "owner": "dapphub",
         "repo": "dapptools",
-        "rev": "5ac152e60ee781e3c85f28ca5bb0d5b44233bf69",
-        "sha256": "19y85m88bip0hiaaw0w54241s4qvyfblipvrc1wh3mpb95knagsl",
+        "rev": "d10dbe5e58a8e1f0dbd9c8f6e959f63172c90cfb",
+        "sha256": "0qq7nn0ck26kmp7zj6ykpszrnn3yxs046fqkirb5y63nlphyw26x",
         "type": "tarball",
-        "url": "https://github.com/dapphub/dapptools/archive/5ac152e60ee781e3c85f28ca5bb0d5b44233bf69.tar.gz",
+        "url": "https://github.com/dapphub/dapptools/archive/d10dbe5e58a8e1f0dbd9c8f6e959f63172c90cfb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {

--- a/src/HEVM.hs
+++ b/src/HEVM.hs
@@ -27,7 +27,6 @@ import Control.Lens hiding (op, pre, (.>))
 import Control.Monad
 import Control.Applicative ((<|>))
 import qualified Data.Vector as Vec
-import Data.Tree
 
 import Print
 
@@ -38,21 +37,21 @@ import EVM.ABI
 import EVM.Concrete
 import EVM.SymExec
 import EVM.Symbolic
-import EVM.Types (SymWord(..), Buffer(..), Addr(..), toSizzle, litBytes, num, var)
-import EVM.Types (w256, SAddr(..))
+import EVM.Types (SymWord(..), Buffer(..), Addr(..), toSizzle, litBytes, num, var, w256, SAddr(..))
 
 type SolcJson = Map Text SolcContract
 
-proveBehaviour :: SolcJson -> Behaviour -> Symbolic (Either (Tree BranchInfo) VM)
+proveBehaviour :: SolcJson -> Behaviour -> Symbolic VerifyResult
 proveBehaviour sources behaviour = do
   preVm <- initialVm sources' behaviour contractMap
   query $ do
-    res <- verify preVm Nothing Nothing (Just postC)
+    res <- verify preVm Nothing Nothing Nothing (Just postC)
     case res of
-      Right _ -> do
+      Cex tree -> do
         showCounterexample preVm Nothing
-        return $ Right preVm :: Query (Either (Tree BranchInfo) VM)
-      Left tree -> return $ Left tree :: Query (Either (Tree BranchInfo) VM)
+        return $ Cex tree
+      Timeout tree -> return $ Timeout tree
+      Qed tree -> return $ Qed tree
 
    where
      -- todo: deal with ambiguities in contract name
@@ -449,4 +448,4 @@ catBytes :: Map Id SMType -> Map Id (SBV String)
 catBytes m = Map.fromList [(name, i) | (name, SymBytes i) <- Map.toList m]
 
 concatMapM :: Monad m => (a -> m [b]) -> [a] -> m [b]
-concatMapM f xs = liftM concat (mapM f xs)
+concatMapM f xs = fmap concat (mapM f xs)


### PR DESCRIPTION
Bumps us to latest dapptools, which lets us fix the issue where act was showing QED if the solver timed out in the hevm backend.