### PR TITLE
Add summary to HEVM output

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -25,7 +25,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as TIO
 import qualified Data.Map.Strict as Map
 import System.Environment (setEnv)
-import System.FilePath.Posix (takeFileName)
 import Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 
 import qualified Data.ByteString.Lazy.Char8 as B
@@ -231,7 +230,7 @@ hevm spec' soljson' solver' smttimeout' smtdebug' = do
     putStrLn . unlines $
       if null failures
         then [ "==== SUCCESS ===="
-             "All behaviours implemented as specified ∎."
+             , "All behaviours implemented as specified ∎."
              ]
         else [ "==== FAILURE ===="
              , show (length failures) <> " out of " <> show (length passes) <> " claims unproven:"

--- a/src/act.cabal
+++ b/src/act.cabal
@@ -14,7 +14,11 @@ common deps
   build-depends: base             >= 4.9 && < 5,
                  aeson            >= 1.0,
                  containers       >= 0.5,
-                 hevm             >= 0.47.1 && < 0.48, -- Ugly upper bound to force usage of version from nix-shell.
+                 hevm             >= 0.47.1 && < 0.48,
+                 -- hevm version has an ugly upper bound to
+                 -- force usage of version from nix-shell,
+                 -- which avoids weird missing deps when
+                 -- pulling it from hackage.
                  lens             >= 4.17.1,
                  text             >= 1.2,
                  array            >= 0.5.3.0,
@@ -26,8 +30,7 @@ common deps
                  utf8-string      >= 1.0.1.1,
                  process          >= 1.6.5.0,
                  ansi-wl-pprint   >= 0.6.9,
-                 regex-tdfa,
-                 filepath
+                 regex-tdfa
   other-modules: Lex ErrM Parse K HEVM Coq Syntax Syntax.Untyped Syntax.Typed Syntax.Annotated Syntax.Timing Syntax.TimeAgnostic Type Print Enrich SMT
   
   if flag(ci)


### PR DESCRIPTION
As we discussed while writing the v0.1 blog post, the current output in the HEVM mode could potentially be misinterpreted by lazy programmers who see `Successfully proved <property>` on the last output line and assume that everything succeeded.

We would like the HEVM mode to finish by outputting a summary of the proof (attempts). This implements that.

A failing example:
```
[nix-shell:~/dev/act/summary]$ bin/act hevm --spec ../../act-examples/src/simple.act --soljson ../../act-examples/out/dapp.sol.json
checking postcondition...
Calldata:
0x60fe47b100000000000000000000000000000000000000000000000000000000000007d0
Caller:
0x0000000000000000000000000000000000000000
Callvalue:
0
Failed to prove set(Pass)
checking postcondition...
Q.E.D.
Successfully proved set(Fail), 2 cases.

==== FAILURE ====
1 out of 2 claims unproven:

1	Failed to prove set(Pass)
```

A succeeding example:
```
[nix-shell:~/dev/act/summary]$ bin/act hevm --spec ../../act-examples/src/simple.act --soljson ../../act-examples/out/dapp.sol.json
checking postcondition...
Q.E.D.
Successfully proved set(Pass), 2 cases.
checking postcondition...
Q.E.D.
Successfully proved set(Fail), 2 cases.

==== SUCCESS ====
../../act-examples/out/dapp.sol.json fully satisfies ../../act-examples/src/simple.act.
```