### PR TITLE
Add source file positions to typed expressions

### DIFF
--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -41,7 +41,6 @@ import Options.Generic
 import Parse
 import Syntax
 import Syntax.Annotated
-import Syntax.Untyped
 import Enrich
 import K hiding (normalize, indent)
 import SMT

--- a/src/Coq.hs
+++ b/src/Coq.hs
@@ -235,67 +235,67 @@ abiVal _ = error "TODO: missing default values"
 coqexp :: Exp a -> T.Text
 
 -- booleans
-coqexp (LitBool True)  = "true"
-coqexp (LitBool False) = "false"
-coqexp (Var SBoolean name)  = T.pack name
-coqexp (And e1 e2)  = parens $ "andb "   <> coqexp e1 <> " " <> coqexp e2
-coqexp (Or e1 e2)   = parens $ "orb"     <> coqexp e1 <> " " <> coqexp e2
-coqexp (Impl e1 e2) = parens $ "implb"   <> coqexp e1 <> " " <> coqexp e2
-coqexp (Eq e1 e2)   = parens $ coqexp e1  <> " =? " <> coqexp e2
-coqexp (NEq e1 e2)  = parens $ "negb " <> parens (coqexp e1  <> " =? " <> coqexp e2)
-coqexp (Neg e)      = parens $ "negb " <> coqexp e
-coqexp (LE e1 e2)   = parens $ coqexp e1 <> " <? "  <> coqexp e2
-coqexp (LEQ e1 e2)  = parens $ coqexp e1 <> " <=? " <> coqexp e2
-coqexp (GE e1 e2)   = parens $ coqexp e2 <> " <? "  <> coqexp e1
-coqexp (GEQ e1 e2)  = parens $ coqexp e2 <> " <=? " <> coqexp e1
+coqexp (LitBool _ True)  = "true"
+coqexp (LitBool _ False) = "false"
+coqexp (Var _ SBoolean name)  = T.pack name
+coqexp (And _ e1 e2)  = parens $ "andb "   <> coqexp e1 <> " " <> coqexp e2
+coqexp (Or _ e1 e2)   = parens $ "orb"     <> coqexp e1 <> " " <> coqexp e2
+coqexp (Impl _ e1 e2) = parens $ "implb"   <> coqexp e1 <> " " <> coqexp e2
+coqexp (Eq _ e1 e2)   = parens $ coqexp e1  <> " =? " <> coqexp e2
+coqexp (NEq _ e1 e2)  = parens $ "negb " <> parens (coqexp e1  <> " =? " <> coqexp e2)
+coqexp (Neg _ e)      = parens $ "negb " <> coqexp e
+coqexp (LE _ e1 e2)   = parens $ coqexp e1 <> " <? "  <> coqexp e2
+coqexp (LEQ _ e1 e2)  = parens $ coqexp e1 <> " <=? " <> coqexp e2
+coqexp (GE _ e1 e2)   = parens $ coqexp e2 <> " <? "  <> coqexp e1
+coqexp (GEQ _ e1 e2)  = parens $ coqexp e2 <> " <=? " <> coqexp e1
 
 -- integers
-coqexp (LitInt i) = T.pack $ show i
-coqexp (Var SInteger name)  = T.pack name
-coqexp (Add e1 e2) = parens $ coqexp e1 <> " + " <> coqexp e2
-coqexp (Sub e1 e2) = parens $ coqexp e1 <> " - " <> coqexp e2
-coqexp (Mul e1 e2) = parens $ coqexp e1 <> " * " <> coqexp e2
-coqexp (Div e1 e2) = parens $ coqexp e1 <> " / " <> coqexp e2
-coqexp (Mod e1 e2) = parens $ "Z.modulo " <> coqexp e1 <> coqexp e2
-coqexp (Exp e1 e2) = parens $ coqexp e1 <> " ^ " <> coqexp e2
-coqexp (IntMin n)  = parens $ "INT_MIN "  <> T.pack (show n)
-coqexp (IntMax n)  = parens $ "INT_MAX "  <> T.pack (show n)
-coqexp (UIntMin n) = parens $ "UINT_MIN " <> T.pack (show n)
-coqexp (UIntMax n) = parens $ "UINT_MAX " <> T.pack (show n)
+coqexp (LitInt _ i) = T.pack $ show i
+coqexp (Var _ SInteger name)  = T.pack name
+coqexp (Add _ e1 e2) = parens $ coqexp e1 <> " + " <> coqexp e2
+coqexp (Sub _ e1 e2) = parens $ coqexp e1 <> " - " <> coqexp e2
+coqexp (Mul _ e1 e2) = parens $ coqexp e1 <> " * " <> coqexp e2
+coqexp (Div _ e1 e2) = parens $ coqexp e1 <> " / " <> coqexp e2
+coqexp (Mod _ e1 e2) = parens $ "Z.modulo " <> coqexp e1 <> coqexp e2
+coqexp (Exp _ e1 e2) = parens $ coqexp e1 <> " ^ " <> coqexp e2
+coqexp (IntMin _ n)  = parens $ "INT_MIN "  <> T.pack (show n)
+coqexp (IntMax _ n)  = parens $ "INT_MAX "  <> T.pack (show n)
+coqexp (UIntMin _ n) = parens $ "UINT_MIN " <> T.pack (show n)
+coqexp (UIntMax _ n) = parens $ "UINT_MAX " <> T.pack (show n)
 
 -- polymorphic
-coqexp (TEntry w e) = entry e w
-coqexp (ITE b e1 e2) = parens $ "if "
-                             <> coqexp b
-                             <> " then "
-                             <> coqexp e1
-                             <> " else "
-                             <> coqexp e2
+coqexp (TEntry _ w e) = entry e w
+coqexp (ITE _ b e1 e2) = parens $ "if "
+                               <> coqexp b
+                               <> " then "
+                               <> coqexp e1
+                               <> " else "
+                               <> coqexp e2
 
 -- unsupported
-coqexp (IntEnv e) = error $ show e <> ": environment values not yet supported"
-coqexp (Cat _ _) = error "bytestrings not supported"
-coqexp (Slice _ _ _) = error "bytestrings not supported"
-coqexp (Var SByteStr _) = error "bytestrings not supported"
-coqexp (ByStr _) = error "bytestrings not supported"
-coqexp (ByLit _) = error "bytestrings not supported"
-coqexp (ByEnv _) = error "bytestrings not supported"
-coqexp (NewAddr _ _) = error "newaddr not supported"
+coqexp (IntEnv _ e) = error $ show e <> ": environment values not yet supported"
+coqexp Cat {} = error "bytestrings not supported"
+coqexp Slice {} = error "bytestrings not supported"
+coqexp (Var _ SByteStr _) = error "bytestrings not supported"
+coqexp ByStr {} = error "bytestrings not supported"
+coqexp ByLit {} = error "bytestrings not supported"
+coqexp ByEnv {} = error "bytestrings not supported"
+coqexp NewAddr {} = error "newaddr not supported"
 
 -- | coq syntax for a proposition
 coqprop :: Exp a -> T.Text
-coqprop (LitBool True)  = "True"
-coqprop (LitBool False) = "False"
-coqprop (And e1 e2)  = parens $ coqprop e1 <> " /\\ " <> coqprop e2
-coqprop (Or e1 e2)   = parens $ coqprop e1 <> " \\/ " <> coqprop e2
-coqprop (Impl e1 e2) = parens $ coqprop e1 <> " -> " <> coqprop e2
-coqprop (Neg e)      = parens $ "not " <> coqprop e
-coqprop (Eq e1 e2)   = parens $ coqexp e1 <> " = "  <> coqexp e2
-coqprop (NEq e1 e2)  = parens $ coqexp e1 <> " <> " <> coqexp e2
-coqprop (LE e1 e2)   = parens $ coqexp e1 <> " < "  <> coqexp e2
-coqprop (LEQ e1 e2)  = parens $ coqexp e1 <> " <= " <> coqexp e2
-coqprop (GE e1 e2)   = parens $ coqexp e1 <> " > "  <> coqexp e2
-coqprop (GEQ e1 e2)  = parens $ coqexp e1 <> " >= " <> coqexp e2
+coqprop (LitBool _ True)  = "True"
+coqprop (LitBool _ False) = "False"
+coqprop (And _ e1 e2)  = parens $ coqprop e1 <> " /\\ " <> coqprop e2
+coqprop (Or _ e1 e2)   = parens $ coqprop e1 <> " \\/ " <> coqprop e2
+coqprop (Impl _ e1 e2) = parens $ coqprop e1 <> " -> " <> coqprop e2
+coqprop (Neg _ e)      = parens $ "not " <> coqprop e
+coqprop (Eq _ e1 e2)   = parens $ coqexp e1 <> " = "  <> coqexp e2
+coqprop (NEq _ e1 e2)  = parens $ coqexp e1 <> " <> " <> coqexp e2
+coqprop (LE _ e1 e2)   = parens $ coqexp e1 <> " < "  <> coqexp e2
+coqprop (LEQ _ e1 e2)  = parens $ coqexp e1 <> " <= " <> coqexp e2
+coqprop (GE _ e1 e2)   = parens $ coqexp e1 <> " > "  <> coqexp e2
+coqprop (GEQ _ e1 e2)  = parens $ coqexp e1 <> " >= " <> coqexp e2
 coqprop _ = error "ill formed proposition"
 
 -- | coq syntax for a typed expression

--- a/src/Enrich.hs
+++ b/src/Enrich.hs
@@ -62,7 +62,7 @@ mkEthEnvBounds vars = catMaybes $ mkBound <$> nub vars
   where
     mkBound :: EthEnv -> Maybe (Exp Bool)
     mkBound e = case lookup e defaultStore of
-      Just Integer -> Just $ bound (toAbiType e) (IntEnv e)
+      Just Integer -> Just $ bound (toAbiType e) (IntEnv nowhere e)
       _ -> Nothing
 
     toAbiType :: EthEnv -> AbiType
@@ -91,7 +91,7 @@ mkStorageBounds store refs = catMaybes $ mkBound <$> refs
     mkBound _ = Nothing
 
     fromItem :: TStorageItem Integer -> Exp Bool
-    fromItem item@(Item _ contract name _) = bound (abiType $ slotType contract name) (TEntry Pre item)
+    fromItem item@(Item _ contract name _) = bound (abiType $ slotType contract name) (TEntry nowhere Pre item)
 
     slotType :: Id -> Id -> SlotType
     slotType contract name = let

--- a/src/K.hs
+++ b/src/K.hs
@@ -19,7 +19,6 @@ import Data.Typeable
 import Data.List hiding (group)
 import Data.Maybe
 import qualified Data.Text as Text
-import Parse
 import EVM.Types hiding (Whiff(..))
 
 import EVM.Solidity (SolcContract(..), StorageItem(..), SlotType(..))
@@ -98,41 +97,41 @@ kTypedExpr (TExp SByteStr _) = error "TODO: add support for TExp SByteStr to kEx
 
 kExpr :: Exp a -> String
 -- integers
-kExpr (Add a b) = "(" <> kExpr a <> " +Int " <> kExpr b <> ")"
-kExpr (Sub a b) = "(" <> kExpr a <> " -Int " <> kExpr b <> ")"
-kExpr (Mul a b) = "(" <> kExpr a <> " *Int " <> kExpr b <> ")"
-kExpr (Div a b) = "(" <> kExpr a <> " /Int " <> kExpr b <> ")"
-kExpr (Mod a b) = "(" <> kExpr a <> " modInt " <> kExpr b <> ")"
-kExpr (Exp a b) = "(" <> kExpr a <> " ^Int " <> kExpr b <> ")"
-kExpr (LitInt a) = show a
-kExpr (IntMin a) = kExpr $ LitInt $ negate $ 2 ^ (a - 1)
-kExpr (IntMax a) = kExpr $ LitInt $ 2 ^ (a - 1) - 1
-kExpr (UIntMin _) = kExpr $ LitInt 0
-kExpr (UIntMax a) = kExpr $ LitInt $ 2 ^ a - 1
-kExpr (IntEnv a) = show a
+kExpr (Add _ a b) = "(" <> kExpr a <> " +Int " <> kExpr b <> ")"
+kExpr (Sub _ a b) = "(" <> kExpr a <> " -Int " <> kExpr b <> ")"
+kExpr (Mul _ a b) = "(" <> kExpr a <> " *Int " <> kExpr b <> ")"
+kExpr (Div _ a b) = "(" <> kExpr a <> " /Int " <> kExpr b <> ")"
+kExpr (Mod _ a b) = "(" <> kExpr a <> " modInt " <> kExpr b <> ")"
+kExpr (Exp _ a b) = "(" <> kExpr a <> " ^Int " <> kExpr b <> ")"
+kExpr (LitInt _ a) = show a
+kExpr (IntMin p a) = kExpr $ LitInt p $ negate $ 2 ^ (a - 1)
+kExpr (IntMax p a) = kExpr $ LitInt p $ 2 ^ (a - 1) - 1
+kExpr (UIntMin p _) = kExpr $ LitInt p 0
+kExpr (UIntMax p a) = kExpr $ LitInt p $ 2 ^ a - 1
+kExpr (IntEnv _ a) = show a
 
 -- booleans
-kExpr (And a b) = "(" <> kExpr a <> " andBool\n " <> kExpr b <> ")"
-kExpr (Or a b) = "(" <> kExpr a <> " orBool " <> kExpr b <> ")"
-kExpr (Impl a b) = "(" <> kExpr a <> " impliesBool " <> kExpr b <> ")"
-kExpr (Neg a) = "notBool (" <> kExpr a <> ")"
-kExpr (LE a b) = "(" <> kExpr a <> " <Int " <> kExpr b <> ")"
-kExpr (LEQ a b) = "(" <> kExpr a <> " <=Int " <> kExpr b <> ")"
-kExpr (GE a b) = "(" <> kExpr a <> " >Int " <> kExpr b <> ")"
-kExpr (GEQ a b) = "(" <> kExpr a <> " >=Int " <> kExpr b <> ")"
-kExpr (LitBool a) = show a
-kExpr (NEq a b) = "notBool (" <> kExpr (Eq a b) <> ")"
-kExpr (Eq (a :: Exp a) (b :: Exp a)) = fromMaybe (error "Internal Error: invalid expression type") $
+kExpr (And _ a b) = "(" <> kExpr a <> " andBool\n " <> kExpr b <> ")"
+kExpr (Or _ a b) = "(" <> kExpr a <> " orBool " <> kExpr b <> ")"
+kExpr (Impl _ a b) = "(" <> kExpr a <> " impliesBool " <> kExpr b <> ")"
+kExpr (Neg _ a) = "notBool (" <> kExpr a <> ")"
+kExpr (LE _ a b) = "(" <> kExpr a <> " <Int " <> kExpr b <> ")"
+kExpr (LEQ _ a b) = "(" <> kExpr a <> " <=Int " <> kExpr b <> ")"
+kExpr (GE _ a b) = "(" <> kExpr a <> " >Int " <> kExpr b <> ")"
+kExpr (GEQ _ a b) = "(" <> kExpr a <> " >=Int " <> kExpr b <> ")"
+kExpr (LitBool _ a) = show a
+kExpr (NEq p a b) = "notBool (" <> kExpr (Eq p a b) <> ")"
+kExpr (Eq p (a :: Exp a) (b :: Exp a)) = fromMaybe (error $ "Internal Error: invalid expression type at pos " ++ show p) $
   let eqK typ = "(" <> kExpr a <> " ==" <> typ <> " " <> kExpr b <> ")"
    in eqT @a @Integer    $> eqK "Int"
   <|> eqT @a @Bool       $> eqK "Bool"
   <|> eqT @a @ByteString $> eqK "K" -- TODO: Is ==K correct?
 
 -- bytestrings
-kExpr (ByStr str) = show str
-kExpr (ByLit bs) = show bs
-kExpr (TEntry t item) = kStorageName t item
-kExpr (Var _ a) = kVar a
+kExpr (ByStr _ str) = show str
+kExpr (ByLit _ bs) = show bs
+kExpr (TEntry _ t item) = kStorageName t item
+kExpr (Var _ _ a) = kVar a
 kExpr v = error ("Internal error: TODO kExpr of " <> show v)
 --kExpr (Cat a b) =
 --kExpr (Slice a start end) =

--- a/src/Print.hs
+++ b/src/Print.hs
@@ -43,46 +43,46 @@ prettyExp :: Exp a t -> String
 prettyExp e = case e of
 
   -- booleans
-  Or a b -> print2 "or" a b
-  Eq a b -> print2 "==" a b
-  LE a b -> print2 "<" a b
-  GE a b -> print2 ">" a b
-  LEQ a b -> print2 "<=" a b
-  GEQ a b -> print2 ">=" a b
-  And a b -> print2 "and" a b
-  NEq a b -> print2 "=/=" a b
-  Neg a -> "(not " <> prettyExp a <> ")"
-  Impl a b -> print2 "=>" a b
-  LitBool b -> if b then "true" else "false"
+  Or _ a b -> print2 "or" a b
+  Eq _ a b -> print2 "==" a b
+  LE _ a b -> print2 "<" a b
+  GE _ a b -> print2 ">" a b
+  LEQ _ a b -> print2 "<=" a b
+  GEQ _ a b -> print2 ">=" a b
+  And _ a b -> print2 "and" a b
+  NEq _ a b -> print2 "=/=" a b
+  Neg _ a -> "(not " <> prettyExp a <> ")"
+  Impl _ a b -> print2 "=>" a b
+  LitBool _ b -> if b then "true" else "false"
 
   -- integers
-  Add a b -> print2 "+" a b
-  Sub a b -> print2 "-" a b
-  Mul a b -> print2 "*" a b
-  Div a b -> print2 "/" a b
-  Mod a b -> print2 "%" a b
-  Exp a b -> print2 "^" a b
-  UIntMax a -> show $ uintmax a
-  UIntMin a -> show $ uintmin a
-  IntMax a -> show $ intmax a
-  IntMin a -> show $ intmin a
-  LitInt a -> show a
-  IntEnv a -> prettyEnv a
+  Add _ a b -> print2 "+" a b
+  Sub _ a b -> print2 "-" a b
+  Mul _ a b -> print2 "*" a b
+  Div _ a b -> print2 "/" a b
+  Mod _ a b -> print2 "%" a b
+  Exp _ a b -> print2 "^" a b
+  UIntMax _ a -> show $ uintmax a
+  UIntMin _ a -> show $ uintmin a
+  IntMax _ a -> show $ intmax a
+  IntMin _ a -> show $ intmin a
+  LitInt _ a -> show a
+  IntEnv _ a -> prettyEnv a
 
   -- bytestrings
-  Cat a b -> print2 "++" a b
-  Slice a b c -> (prettyExp a) <> "[" <> (prettyExp b) <> ":" <> (prettyExp c) <> "]"
-  ByStr a -> a
-  ByLit a -> toString a
-  ByEnv a -> prettyEnv a
+  Cat _ a b -> print2 "++" a b
+  Slice _ a b c -> (prettyExp a) <> "[" <> (prettyExp b) <> ":" <> (prettyExp c) <> "]"
+  ByStr _ a -> a
+  ByLit _ a -> toString a
+  ByEnv _ a -> prettyEnv a
 
   -- builtins
-  NewAddr addr nonce -> "newAddr(" <> prettyExp addr <> ", " <> prettyExp nonce <> ")"
+  NewAddr _ addr nonce -> "newAddr(" <> prettyExp addr <> ", " <> prettyExp nonce <> ")"
 
   --polymorphic
-  ITE a b c -> "(if " <> prettyExp a <> " then " <> prettyExp b <> " else " <> prettyExp c <> ")"
-  TEntry t a -> timeParens t $ prettyItem a
-  Var _ x -> x
+  ITE _ a b c -> "(if " <> prettyExp a <> " then " <> prettyExp b <> " else " <> prettyExp c <> ")"
+  TEntry _ t a -> timeParens t $ prettyItem a
+  Var _ _ x -> x
   where
     print2 sym a b = "(" <> prettyExp a <> " " <> sym <> " " <> prettyExp b <> ")"
 
@@ -131,35 +131,35 @@ prettyInvPred = prettyExp . untime . fst
 
     untime :: Exp a t -> Exp a Untimed
     untime e = case e of
-      And a b   -> And (untime a) (untime b)
-      Or a b    -> Or (untime a) (untime b)
-      Impl a b  -> Impl (untime a) (untime b)
-      Eq a b    -> Eq (untime a) (untime b)
-      LE a b    -> LE (untime a) (untime b)
-      LEQ a b   -> LEQ (untime a) (untime b)
-      GE a b    -> GE (untime a) (untime b)
-      GEQ a b   -> GEQ (untime a) (untime b)
-      NEq a b   -> NEq (untime a) (untime b)
-      Neg a     -> Neg (untime a)
-      Add a b   -> Add (untime a) (untime b)
-      Sub a b   -> Sub (untime a) (untime b)
-      Mul a b   -> Mul (untime a) (untime b)
-      Div a b   -> Div (untime a) (untime b)
-      Mod a b   -> Mod (untime a) (untime b)
-      Exp a b   -> Exp (untime a) (untime b)
-      Cat a b   -> Cat (untime a) (untime b)
-      ByStr a   -> ByStr a
-      ByLit a   -> ByLit a
-      LitInt a  -> LitInt a
-      IntMin a  -> IntMin a
-      IntMax a  -> IntMax a
-      UIntMin a -> UIntMin a
-      UIntMax a -> UIntMax a
-      LitBool a -> LitBool a
-      IntEnv a  -> IntEnv a
-      ByEnv a   -> ByEnv a
-      ITE x y z -> ITE (untime x) (untime y) (untime z)
-      NewAddr a b -> NewAddr (untime a) (untime b)
-      Slice a b c -> Slice (untime a) (untime b) (untime c)
-      TEntry _ (Item t a b c) -> TEntry Neither (Item t a b (fmap untimeTyped c))
-      Var t a -> Var t a
+      And p a b   -> And p (untime a) (untime b)
+      Or p a b    -> Or p (untime a) (untime b)
+      Impl p a b  -> Impl p (untime a) (untime b)
+      Eq p a b    -> Eq p (untime a) (untime b)
+      LE p a b    -> LE p (untime a) (untime b)
+      LEQ p a b   -> LEQ p (untime a) (untime b)
+      GE p a b    -> GE p (untime a) (untime b)
+      GEQ p a b   -> GEQ p (untime a) (untime b)
+      NEq p a b   -> NEq p (untime a) (untime b)
+      Neg p a     -> Neg p (untime a)
+      Add p a b   -> Add p (untime a) (untime b)
+      Sub p a b   -> Sub p (untime a) (untime b)
+      Mul p a b   -> Mul p (untime a) (untime b)
+      Div p a b   -> Div p (untime a) (untime b)
+      Mod p a b   -> Mod p (untime a) (untime b)
+      Exp p a b   -> Exp p (untime a) (untime b)
+      Cat p a b   -> Cat p (untime a) (untime b)
+      ByStr p a   -> ByStr p a
+      ByLit p a   -> ByLit p a
+      LitInt p a  -> LitInt p a
+      IntMin p a  -> IntMin p a
+      IntMax p a  -> IntMax p a
+      UIntMin p a -> UIntMin p a
+      UIntMax p a -> UIntMax p a
+      LitBool p a -> LitBool p a
+      IntEnv p a  -> IntEnv p a
+      ByEnv p a   -> ByEnv p a
+      ITE p x y z -> ITE p (untime x) (untime y) (untime z)
+      NewAddr p a b -> NewAddr p (untime a) (untime b)
+      Slice p a b c -> Slice p (untime a) (untime b) (untime c)
+      TEntry p _ (Item t a b c) -> TEntry p Neither (Item t a b (fmap untimeTyped c))
+      Var p t a -> Var p t a

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -68,38 +68,38 @@ locsFromExp = nub . go
   where
     go :: Exp a t -> [StorageLocation t]
     go e = case e of
-      And a b   -> go a <> go b
-      Or a b    -> go a <> go b
-      Impl a b  -> go a <> go b
-      Eq a b    -> go a <> go b
-      LE a b    -> go a <> go b
-      LEQ a b   -> go a <> go b
-      GE a b    -> go a <> go b
-      GEQ a b   -> go a <> go b
-      NEq a b   -> go a <> go b
-      Neg a     -> go a
-      Add a b   -> go a <> go b
-      Sub a b   -> go a <> go b
-      Mul a b   -> go a <> go b
-      Div a b   -> go a <> go b
-      Mod a b   -> go a <> go b
-      Exp a b   -> go a <> go b
-      Cat a b   -> go a <> go b
-      Slice a b c -> go a <> go b <> go c
-      ByStr _ -> []
-      ByLit _ -> []
-      LitInt _  -> []
-      IntMin _  -> []
-      IntMax _  -> []
-      UIntMin _ -> []
-      UIntMax _ -> []
-      LitBool _ -> []
-      NewAddr a b -> go a <> go b
-      IntEnv _ -> []
-      ByEnv _ -> []
-      ITE x y z -> go x <> go y <> go z
-      TEntry _ a -> locsFromItem a
-      Var _ _ -> []
+      And _ a b   -> go a <> go b
+      Or _ a b    -> go a <> go b
+      Impl _ a b  -> go a <> go b
+      Eq _ a b    -> go a <> go b
+      LE _ a b    -> go a <> go b
+      LEQ _ a b   -> go a <> go b
+      GE _ a b    -> go a <> go b
+      GEQ _ a b   -> go a <> go b
+      NEq _ a b   -> go a <> go b
+      Neg _ a     -> go a
+      Add _ a b   -> go a <> go b
+      Sub _ a b   -> go a <> go b
+      Mul _ a b   -> go a <> go b
+      Div _ a b   -> go a <> go b
+      Mod _ a b   -> go a <> go b
+      Exp _ a b   -> go a <> go b
+      Cat _ a b   -> go a <> go b
+      Slice _ a b c -> go a <> go b <> go c
+      ByStr {} -> []
+      ByLit {} -> []
+      LitInt {}  -> []
+      IntMin {}  -> []
+      IntMax {}  -> []
+      UIntMin {} -> []
+      UIntMax {} -> []
+      LitBool {} -> []
+      NewAddr _ a b -> go a <> go b
+      IntEnv {} -> []
+      ByEnv {} -> []
+      ITE _ x y z -> go x <> go y <> go z
+      TEntry _ _ a -> locsFromItem a
+      Var {} -> []
 
 ethEnvFromBehaviour :: Behaviour t -> [EthEnv]
 ethEnvFromBehaviour (Behaviour _ _ _ _ preconds postconds rewrites returns) = nub $
@@ -131,38 +131,38 @@ ethEnvFromExp = nub . go
   where
     go :: Exp a t -> [EthEnv]
     go e = case e of
-      And a b   -> go a <> go b
-      Or a b    -> go a <> go b
-      Impl a b  -> go a <> go b
-      Eq a b    -> go a <> go b
-      LE a b    -> go a <> go b
-      LEQ a b   -> go a <> go b
-      GE a b    -> go a <> go b
-      GEQ a b   -> go a <> go b
-      NEq a b   -> go a <> go b
-      Neg a     -> go a
-      Add a b   -> go a <> go b
-      Sub a b   -> go a <> go b
-      Mul a b   -> go a <> go b
-      Div a b   -> go a <> go b
-      Mod a b   -> go a <> go b
-      Exp a b   -> go a <> go b
-      Cat a b   -> go a <> go b
-      Slice a b c -> go a <> go b <> go c
-      ITE a b c -> go a <> go b <> go c
-      ByStr _ -> []
-      ByLit _ -> []
-      LitInt _  -> []
-      LitBool _ -> []
-      IntMin _ -> []
-      IntMax _ -> []
-      UIntMin _ -> []
-      UIntMax _ -> []
-      NewAddr a b -> go a <> go b
-      IntEnv a -> [a]
-      ByEnv a -> [a]
-      TEntry _ a -> ethEnvFromItem a
-      Var _ _ -> []
+      And   _ a b   -> go a <> go b
+      Or    _ a b   -> go a <> go b
+      Impl  _ a b   -> go a <> go b
+      Eq    _ a b   -> go a <> go b
+      LE    _ a b   -> go a <> go b
+      LEQ   _ a b   -> go a <> go b
+      GE    _ a b   -> go a <> go b
+      GEQ   _ a b   -> go a <> go b
+      NEq   _ a b   -> go a <> go b
+      Neg   _ a     -> go a
+      Add   _ a b   -> go a <> go b
+      Sub   _ a b   -> go a <> go b
+      Mul   _ a b   -> go a <> go b
+      Div   _ a b   -> go a <> go b
+      Mod   _ a b   -> go a <> go b
+      Exp   _ a b   -> go a <> go b
+      Cat   _ a b   -> go a <> go b
+      Slice _ a b c -> go a <> go b <> go c
+      ITE   _ a b c -> go a <> go b <> go c
+      ByStr {} -> []
+      ByLit {} -> []
+      LitInt {}  -> []
+      LitBool {} -> []
+      IntMin {} -> []
+      IntMax {} -> []
+      UIntMin {} -> []
+      UIntMax {} -> []
+      NewAddr _ a b -> go a <> go b
+      IntEnv _ a -> [a]
+      ByEnv _ a -> [a]
+      TEntry _ _ a -> ethEnvFromItem a
+      Var {} -> []
 
 idFromRewrite :: Rewrite t -> Id
 idFromRewrite = onRewrite idFromLocation idFromUpdate

--- a/src/Syntax/Types.hs
+++ b/src/Syntax/Types.hs
@@ -63,7 +63,9 @@ instance SingI Bool       where sing = SBoolean
 instance SingI ByteString where sing = SByteStr
 
 -- | A non-indexed type whose inhabitants represent the types understood
--- by proving tools. Implemented by an existentially quantified 'SType'.
+-- by proving tools. Implemented by an existentially quantified 'SType',
+-- but it is recommended to use the patterns 'Syntax.Types.Integer', 'Boolean'
+-- and 'ByteStr' whenever constructing or matching on these.
 type ActType = SomeSing *
 
 pattern Integer :: ActType

--- a/src/Syntax/Untyped.hs
+++ b/src/Syntax/Untyped.hs
@@ -3,7 +3,7 @@
 -- It is also equipped with position information for extra debugging xp
 {-# LANGUAGE OverloadedStrings #-}
 
-module Syntax.Untyped where
+module Syntax.Untyped (module Syntax.Untyped) where
 
 import Data.Aeson
 import Data.List (intercalate)

--- a/src/act.cabal
+++ b/src/act.cabal
@@ -33,7 +33,8 @@ common deps
                  regex-tdfa,
                  validation       >= 1.1.1,
                  extra,
-                 singletons
+                 singletons,
+                 deriving-compat
   if flag(ci)
       ghc-options: -O2 -Wall -Werror -Wno-orphans -Wno-unticked-promoted-constructors
   else

--- a/src/test/Test.hs
+++ b/src/test/Test.hs
@@ -57,7 +57,7 @@ main = defaultMain $ testGroup "act"
                   [ S Map.empty, B behv ]
                 else
                   [ S Map.empty, B behv
-                  , B $ Behaviour name Fail contract iface [Neg $ mconcat preconds] [] [] Nothing ]
+                  , B $ Behaviour name Fail contract iface [Neg nowhere $ mconcat preconds] [] [] Nothing ]
           return $ case actual of
             Success a -> a === expected
             Failure _ -> property False
@@ -160,21 +160,21 @@ genExpBytes names _ = _Var <$> selectName ByteStr names
 genExpBool :: Names -> Int -> ExpoGen (Exp Bool)
 genExpBool names 0 = oneof
   [ _Var <$> selectName Boolean names
-  , LitBool <$> liftGen arbitrary
+  , LitBool nowhere <$> liftGen arbitrary
   ]
 genExpBool names n = oneof
-  [ liftM2 And subExpBool subExpBool
-  , liftM2 Or subExpBool subExpBool
-  , liftM2 Impl subExpBool subExpBool
-  , liftM2 Eq subExpInt subExpInt
-  , liftM2 Eq subExpBool subExpBool
-  , liftM2 Eq subExpBytes subExpBytes
-  , liftM2 NEq subExpInt subExpInt
-  , liftM2 LE subExpInt subExpInt
-  , liftM2 LEQ subExpInt subExpInt
-  , liftM2 GEQ subExpInt subExpInt
-  , liftM2 GE subExpInt subExpInt
-  , Neg <$> subExpBool
+  [ liftM2 (And nowhere) subExpBool subExpBool
+  , liftM2 (Or nowhere) subExpBool subExpBool
+  , liftM2 (Impl nowhere) subExpBool subExpBool
+  , liftM2 (Eq nowhere) subExpInt subExpInt
+  , liftM2 (Eq nowhere) subExpBool subExpBool
+  , liftM2 (Eq nowhere) subExpBytes subExpBytes
+  , liftM2 (NEq nowhere) subExpInt subExpInt
+  , liftM2 (LE nowhere) subExpInt subExpInt
+  , liftM2 (LEQ nowhere) subExpInt subExpInt
+  , liftM2 (GEQ nowhere) subExpInt subExpInt
+  , liftM2 (GE nowhere) subExpInt subExpInt
+  , Neg nowhere <$> subExpBool
   ]
   where subExpBool = genExpBool names (n `div` 2)
         subExpBytes = genExpBytes names (n `div` 2)
@@ -184,33 +184,33 @@ genExpBool names n = oneof
 -- TODO: storage
 genExpInt :: Names -> Int -> ExpoGen (Exp Integer)
 genExpInt names 0 = oneof
-  [ LitInt <$> liftGen arbitrary
+  [ LitInt nowhere <$> liftGen arbitrary
   , _Var <$> selectName Integer names
-  , return $ IntEnv Caller
-  , return $ IntEnv Callvalue
-  , return $ IntEnv Calldepth
-  , return $ IntEnv Origin
-  , return $ IntEnv Blocknumber
-  , return $ IntEnv Difficulty
-  , return $ IntEnv Chainid
-  , return $ IntEnv Gaslimit
-  , return $ IntEnv Coinbase
-  , return $ IntEnv Timestamp
-  , return $ IntEnv This
-  , return $ IntEnv Nonce
+  , return $ IntEnv nowhere Caller
+  , return $ IntEnv nowhere Callvalue
+  , return $ IntEnv nowhere Calldepth
+  , return $ IntEnv nowhere Origin
+  , return $ IntEnv nowhere Blocknumber
+  , return $ IntEnv nowhere Difficulty
+  , return $ IntEnv nowhere Chainid
+  , return $ IntEnv nowhere Gaslimit
+  , return $ IntEnv nowhere Coinbase
+  , return $ IntEnv nowhere Timestamp
+  , return $ IntEnv nowhere This
+  , return $ IntEnv nowhere Nonce
   ]
 genExpInt names n = do
   expo <- lift ask
   oneof $
     (if expo
-      then ((liftM2 Exp subExpInt subExpInt):)
+      then ((liftM2 (Exp nowhere) subExpInt subExpInt):)
       else id)
-        [ liftM2 Add subExpInt subExpInt
-        , liftM2 Sub subExpInt subExpInt
-        , liftM2 Mul subExpInt subExpInt
-        , liftM2 Div subExpInt subExpInt
-        , liftM2 Mod subExpInt subExpInt
-        , liftM3 ITE subExpBool subExpInt subExpInt
+        [ liftM2 (Add nowhere) subExpInt subExpInt
+        , liftM2 (Sub nowhere) subExpInt subExpInt
+        , liftM2 (Mul nowhere) subExpInt subExpInt
+        , liftM2 (Div nowhere) subExpInt subExpInt
+        , liftM2 (Mod nowhere) subExpInt subExpInt
+        , liftM3 (ITE nowhere) subExpBool subExpInt subExpInt
         ]
   where subExpInt = genExpInt names (n `div` 2)
         subExpBool = genExpBool names (n `div` 2)


### PR DESCRIPTION
This changes absolutely no behavior, but makes it possible for the various backends to generate error messages which include a pointer to the source file position corresponding to the error. It will be used when unifying error handling.