### PR TITLE
New `checkExpr` for Act

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,9 @@ typing_fail=$(frontend_fail)
 parser_fail=$(filter-out $(typing_fail), $(frontend_fail))
 
 invariant_specs=$(wildcard tests/invariants/*/*.act)
-invariant_pass=$(wildcard tests/invariants/pass/*.act) $(typing_pass)
+invariant_pass=$(filter-out $(invariant_buggy), $(wildcard tests/invariants/pass/*.act) $(typing_pass))
 invariant_fail=$(wildcard tests/invariants/fail/*.act)
+invariant_buggy=tests/invariants/pass/amm-full.act
 
 postcondition_specs=$(wildcard tests/postconditions/*/*.act)
 postcondition_pass=$(wildcard tests/postconditions/pass/*.act) $(typing_pass)

--- a/src/Coq.hs
+++ b/src/Coq.hs
@@ -260,8 +260,8 @@ coqexp (Var _ SBoolean name)  = T.pack name
 coqexp (And _ e1 e2)  = parens $ "andb "   <> coqexp e1 <> " " <> coqexp e2
 coqexp (Or _ e1 e2)   = parens $ "orb"     <> coqexp e1 <> " " <> coqexp e2
 coqexp (Impl _ e1 e2) = parens $ "implb"   <> coqexp e1 <> " " <> coqexp e2
-coqexp (Eq _ e1 e2)   = parens $ coqexp e1  <> " =? " <> coqexp e2
-coqexp (NEq _ e1 e2)  = parens $ "negb " <> parens (coqexp e1  <> " =? " <> coqexp e2)
+coqexp (Eq _ _ e1 e2)   = parens $ coqexp e1  <> " =? " <> coqexp e2
+coqexp (NEq _ _ e1 e2)  = parens $ "negb " <> parens (coqexp e1  <> " =? " <> coqexp e2)
 coqexp (Neg _ e)      = parens $ "negb " <> coqexp e
 coqexp (LT _ e1 e2)   = parens $ coqexp e1 <> " <? "  <> coqexp e2
 coqexp (LEQ _ e1 e2)  = parens $ coqexp e1 <> " <=? " <> coqexp e2
@@ -312,8 +312,8 @@ coqprop (And _ e1 e2)  = parens $ coqprop e1 <> " /\\ " <> coqprop e2
 coqprop (Or _ e1 e2)   = parens $ coqprop e1 <> " \\/ " <> coqprop e2
 coqprop (Impl _ e1 e2) = parens $ coqprop e1 <> " -> " <> coqprop e2
 coqprop (Neg _ e)      = parens $ "not " <> coqprop e
-coqprop (Eq _ e1 e2)   = parens $ coqexp e1 <> " = "  <> coqexp e2
-coqprop (NEq _ e1 e2)  = parens $ coqexp e1 <> " <> " <> coqexp e2
+coqprop (Eq _ _ e1 e2)   = parens $ coqexp e1 <> " = "  <> coqexp e2
+coqprop (NEq _ _ e1 e2)  = parens $ coqexp e1 <> " <> " <> coqexp e2
 coqprop (LT _ e1 e2)   = parens $ coqexp e1 <> " < "  <> coqexp e2
 coqprop (LEQ _ e1 e2)  = parens $ coqexp e1 <> " <= " <> coqexp e2
 coqprop (GT _ e1 e2)   = parens $ coqexp e1 <> " > "  <> coqexp e2

--- a/src/Enrich.hs
+++ b/src/Enrich.hs
@@ -104,5 +104,5 @@ mkStorageBounds store refs = catMaybes $ mkBound <$> refs
 
 mkCallDataBounds :: [Decl] -> [Exp ABoolean]
 mkCallDataBounds = concatMap $ \(Decl typ name) -> case fromAbiType typ of
-  AInteger -> [bound typ (Var nowhere SInteger name)]
+  AInteger -> [bound typ (_Var name)]
   _ -> []

--- a/src/Error.hs
+++ b/src/Error.hs
@@ -50,3 +50,13 @@ notAtPosn p = find valid
   where
     valid (Success _)    = True
     valid (Failure errs) = all ((p /=) . fst) errs
+
+-- | Try to find a succesfull computation in a list, and if it fails
+-- it returns a default computation
+findSuccess :: Error e a -> [Error e a] -> Error e a
+findSuccess d comp = case find valid comp of
+                       Just a -> a
+                       Nothing -> d
+  where
+    valid (Success _) = True
+    valid _ = False

--- a/src/HEVM.hs
+++ b/src/HEVM.hs
@@ -238,7 +238,7 @@ locateCalldata b decls calldata' d@(Decl typ name) =
               ++ name ++ " in interface declaration"))
           (elemIndex d decls)
 
-    val = case actType typ of
+    val = case fromAbiType typ of
       -- all integers are 32 bytes
       AInteger -> let S _ w = readSWord offset calldata'
                  in SymInteger $ sFromIntegral w

--- a/src/HEVM.hs
+++ b/src/HEVM.hs
@@ -25,7 +25,6 @@ import Data.SBV
 import Data.SBV.String ((.++), subStr)
 import Control.Lens hiding (op, pre, (.>))
 import Control.Monad
-import Control.Applicative ((<|>))
 import qualified Data.Vector as Vec
 
 import Print
@@ -241,10 +240,10 @@ locateCalldata b decls calldata' d@(Decl typ name) =
 
     val = case actType typ of
       -- all integers are 32 bytes
-      Integer -> let S _ w = readSWord offset calldata'
+      AInteger -> let S _ w = readSWord offset calldata'
                  in SymInteger $ sFromIntegral w
       -- interpret all nonzero values as boolean true
-      Boolean -> SymBool $ readSWord offset calldata' ./= 0
+      ABoolean -> SymBool $ readSWord offset calldata' ./= 0
       _ -> error "TODO: support bytes"
 
 -- | Embed an SActType as a list of symbolic bytes
@@ -308,7 +307,7 @@ symExp ctx (TExp t e) = case t of
   SBoolean -> SymBool    $ symExpBool  ctx e
   SByteStr -> SymBytes   $ symExpBytes ctx e
 
-symExpBool :: Ctx -> Exp Bool -> SBV Bool
+symExpBool :: Ctx -> Exp ABoolean -> SBV Bool
 symExpBool ctx@(Ctx c m args store _) e = case e of
   And _ a b   -> symExpBool ctx a .&& symExpBool ctx b
   Or _ a b    -> symExpBool ctx a .|| symExpBool ctx b
@@ -317,18 +316,17 @@ symExpBool ctx@(Ctx c m args store _) e = case e of
   LEQ _ a b   -> symExpInt ctx a .<= symExpInt ctx b
   GT _ a b    -> symExpInt ctx a .> symExpInt ctx b
   GEQ _ a b   -> symExpInt ctx a .>= symExpInt ctx b
-  NEq p a b   -> sNot (symExpBool ctx (Eq p a b))
+  NEq p t a b   -> sNot (symExpBool ctx (Eq p t a b))
   Neg _ a     -> sNot (symExpBool ctx a)
   LitBool _ a -> literal a
   Var _ _ a   -> get (nameFromArg c m a) (catBools args)
   TEntry _ t a -> get (nameFromItem m a) (catBools $ timeStore t store)
   ITE _ x y z -> ite (symExpBool ctx x) (symExpBool ctx y) (symExpBool ctx z)
-  Eq p a b -> fromMaybe (error $ "Internal error: invalid expression type at " ++ show p)
-      $ [symExpBool  ctx a' .== symExpBool  ctx b' | a' <- castType a, b' <- castType b]
-    <|> [symExpInt   ctx a' .== symExpInt   ctx b' | a' <- castType a, b' <- castType b]
-    <|> [symExpBytes ctx a' .== symExpBytes ctx b' | a' <- castType a, b' <- castType b]
+  Eq _ SInteger a b -> symExpInt  ctx a .== symExpInt  ctx b
+  Eq _ SBoolean a b -> symExpBool  ctx a .== symExpBool  ctx b
+  Eq _ SByteStr a b -> symExpBytes  ctx a .== symExpBytes  ctx b
 
-symExpInt :: Ctx -> Exp Integer -> SBV Integer
+symExpInt :: Ctx -> Exp AInteger -> SBV Integer
 symExpInt ctx@(Ctx c m args store environment) e = case e of
   Add _ a b   -> symExpInt ctx a + symExpInt ctx b
   Sub _ a b   -> symExpInt ctx a - symExpInt ctx b
@@ -346,7 +344,7 @@ symExpInt ctx@(Ctx c m args store environment) e = case e of
   IntEnv _ a -> get (nameFromEnv c m a) (catInts environment)
   ITE _ x y z -> ite (symExpBool ctx x) (symExpInt ctx y) (symExpInt ctx z)
 
-symExpBytes :: Ctx -> Exp ByteString -> SBV String
+symExpBytes :: Ctx -> Exp AByteStr -> SBV String
 symExpBytes ctx@(Ctx c m args store environment) e = case e of
   Cat _ a b -> symExpBytes ctx a .++ symExpBytes ctx b
   Var _ _ a -> get (nameFromArg c m a) (catBytes args)
@@ -395,8 +393,8 @@ nameFromExp c m e = case e of
   GEQ _ a b   -> nameFromExp c m a <> ">=" <> nameFromExp c m b
   Neg _ a     -> "~" <> nameFromExp c m a
   LitBool _ a -> show a
-  Eq _ a b    -> nameFromExp c m a <> "=="  <> nameFromExp c m b
-  NEq _ a b   -> nameFromExp c m a <> "=/=" <> nameFromExp c m b
+  Eq _ _ a b    -> nameFromExp c m a <> "=="  <> nameFromExp c m b
+  NEq _ _ a b   -> nameFromExp c m a <> "=/=" <> nameFromExp c m b
   Cat _ a b -> nameFromExp c m a <> "++" <> nameFromExp c m b
   ByStr _ a -> show a
   ByLit _ a -> show a

--- a/src/K.hs
+++ b/src/K.hs
@@ -120,7 +120,7 @@ kExpr (GT _ a b) = "(" <> kExpr a <> " >Int " <> kExpr b <> ")"
 kExpr (GEQ _ a b) = "(" <> kExpr a <> " >=Int " <> kExpr b <> ")"
 kExpr (LitBool _ a) = show a
 kExpr (NEq p t a b) = "notBool (" <> kExpr (Eq p t a b) <> ")"
-kExpr (Eq p t a b) =
+kExpr (Eq _ t a b) =
   let eqK typ = "(" <> kExpr a <> " ==" <> typ <> " " <> kExpr b <> ")"
   in case t of
        SInteger -> eqK "Int"

--- a/src/K.hs
+++ b/src/K.hs
@@ -14,10 +14,7 @@ import Syntax
 import Syntax.Annotated
 
 import Error
-import Control.Applicative ((<|>))
-import Data.Functor (($>))
 import Data.Text (Text, pack, unpack)
-import Data.Typeable
 import Data.List hiding (group)
 import Data.Maybe
 import qualified Data.Text as Text
@@ -122,12 +119,13 @@ kExpr (LEQ _ a b) = "(" <> kExpr a <> " <=Int " <> kExpr b <> ")"
 kExpr (GT _ a b) = "(" <> kExpr a <> " >Int " <> kExpr b <> ")"
 kExpr (GEQ _ a b) = "(" <> kExpr a <> " >=Int " <> kExpr b <> ")"
 kExpr (LitBool _ a) = show a
-kExpr (NEq p a b) = "notBool (" <> kExpr (Eq p a b) <> ")"
-kExpr (Eq p (a :: Exp a) (b :: Exp a)) = fromMaybe (error $ "Internal Error: invalid expression type at pos " ++ show p) $
+kExpr (NEq p t a b) = "notBool (" <> kExpr (Eq p t a b) <> ")"
+kExpr (Eq p t a b) =
   let eqK typ = "(" <> kExpr a <> " ==" <> typ <> " " <> kExpr b <> ")"
-   in eqT @a @Integer    $> eqK "Int"
-  <|> eqT @a @Bool       $> eqK "Bool"
-  <|> eqT @a @ByteString $> eqK "K" -- TODO: Is ==K correct?
+  in case t of
+       SInteger -> eqK "Int"
+       SBoolean -> eqK "Bool"
+       SByteStr -> eqK "K"
 
 -- bytestrings
 kExpr (ByStr _ str) = show str

--- a/src/Print.hs
+++ b/src/Print.hs
@@ -45,13 +45,13 @@ prettyExp e = case e of
 
   -- booleans
   Or _ a b -> print2 "or" a b
-  Eq _ a b -> print2 "==" a b
+  Eq _ _ a b -> print2 "==" a b
   LT _ a b -> print2 "<" a b
   GT _ a b -> print2 ">" a b
   LEQ _ a b -> print2 "<=" a b
   GEQ _ a b -> print2 ">=" a b
   And _ a b -> print2 "and" a b
-  NEq _ a b -> print2 "=/=" a b
+  NEq _ _ a b -> print2 "=/=" a b
   Neg _ a -> "(not " <> prettyExp a <> ")"
   Impl _ a b -> print2 "=>" a b
   LitBool _ b -> if b then "true" else "false"
@@ -132,12 +132,12 @@ prettyInvPred = prettyExp . untime . fst
       And p a b   -> And p (untime a) (untime b)
       Or p a b    -> Or p (untime a) (untime b)
       Impl p a b  -> Impl p (untime a) (untime b)
-      Eq p a b    -> Eq p (untime a) (untime b)
+      Eq p t a b    -> Eq p t (untime a) (untime b)
       LT p a b    -> LT p (untime a) (untime b)
       LEQ p a b   -> LEQ p (untime a) (untime b)
       GT p a b    -> GT p (untime a) (untime b)
       GEQ p a b   -> GEQ p (untime a) (untime b)
-      NEq p a b   -> NEq p (untime a) (untime b)
+      NEq p t a b   -> NEq p t (untime a) (untime b)
       Neg p a     -> Neg p (untime a)
       Add p a b   -> Add p (untime a) (untime b)
       Sub p a b   -> Sub p (untime a) (untime b)

--- a/src/SMT.hs
+++ b/src/SMT.hs
@@ -474,9 +474,9 @@ getValue solver name = sendCommand solver $ "(get-value (" <> name <> "))"
 -- | Parse the result of a call to getValue as the supplied type.
 parseModel :: SType a -> String -> TypedExp
 parseModel = \case
-  SInteger -> TExp SInteger . LitInt  nowhere . read       . parseSMTModel
-  SBoolean -> TExp SBoolean . LitBool nowhere . readBool   . parseSMTModel
-  SByteStr -> TExp SByteStr . ByLit   nowhere . fromString . parseSMTModel
+  SInteger -> _TExp . LitInt  nowhere . read       . parseSMTModel
+  SBoolean -> _TExp . LitBool nowhere . readBool   . parseSMTModel
+  SByteStr -> _TExp . ByLit   nowhere . fromString . parseSMTModel
   where
     readBool "true" = True
     readBool "false" = False

--- a/src/SMT.hs
+++ b/src/SMT.hs
@@ -42,7 +42,6 @@ import Data.Maybe
 import Data.List
 import GHC.IO.Handle (Handle, hGetLine, hPutStr, hFlush)
 import Data.ByteString.UTF8 (fromString)
-import Data.Singletons (SomeSing(..))
 
 import Syntax
 import Syntax.Annotated

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -15,7 +15,6 @@ import Data.List
 import Data.Map (Map,empty,insertWith,unionsWith)
 
 import Syntax.TimeAgnostic as Agnostic
--- import Syntax.Types
 import qualified Syntax.Annotated as Annotated
 import           Syntax.Untyped hiding (Constant,Rewrite)
 import qualified Syntax.Untyped as Untyped

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -58,10 +58,10 @@ locFromRewrite :: Rewrite t -> StorageLocation t
 locFromRewrite = onRewrite id locFromUpdate
 
 locFromUpdate :: StorageUpdate t -> StorageLocation t
-locFromUpdate (Update t item _) = Loc t item
+locFromUpdate (Update _ item _) = _Loc item
 
 locsFromItem :: TStorageItem a t -> [StorageLocation t]
-locsFromItem item = Loc (typeFromItem item) item : concatMap locsFromTypedExp (ixsFromItem item)
+locsFromItem item = _Loc item : concatMap locsFromTypedExp (ixsFromItem item)
 
 locsFromTypedExp :: TypedExp t -> [StorageLocation t]
 locsFromTypedExp (TExp _ e) = locsFromExp e
@@ -185,9 +185,6 @@ contractFromItem (Item _ c _ _) = c
 
 ixsFromItem :: TStorageItem a t -> [TypedExp t]
 ixsFromItem (Item _ _ _ ixs) = ixs
-
-typeFromItem :: TStorageItem a t -> SType a
-typeFromItem (Item t _ _ _) = t
 
 contractsInvolved :: Behaviour t -> [Id]
 contractsInvolved = fmap contractFromRewrite . _stateUpdates

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -207,8 +207,8 @@ ixsFromUpdate (Update _ item _) = ixsFromItem item
 ixsFromRewrite :: Rewrite t -> [TypedExp t]
 ixsFromRewrite = onRewrite ixsFromLocation ixsFromUpdate
 
--- itemType :: TStorageItem a t -> ActType
--- itemType item =
+itemType :: TStorageItem a t -> ActType
+itemType (Item t _ _ _) = actType t
 
 isMapping :: StorageLocation t -> Bool
 isMapping = not . null . ixsFromLocation

--- a/src/Syntax/TimeAgnostic.hs
+++ b/src/Syntax/TimeAgnostic.hs
@@ -141,8 +141,8 @@ data StorageLocation (t :: Timing) where
   Loc :: SType a -> TStorageItem a t -> StorageLocation t
 deriving instance Show (StorageLocation t)
 
-_Loc :: forall a t. SingI a => TStorageItem a t -> StorageLocation t
-_Loc item = Loc (sing @a) item
+_Loc :: TStorageItem a t -> StorageLocation t
+_Loc item@(Item s _ _ _ ) = Loc s item
 
 instance Eq (StorageLocation t) where
   Loc s1 i1 == Loc s2 i2 = eqS s1 i1 s2 i2

--- a/src/Syntax/TimeAgnostic.hs
+++ b/src/Syntax/TimeAgnostic.hs
@@ -519,8 +519,15 @@ eval e = case e of
   ByStr _ s     -> pure . fromString $ s
   ByLit _ s     -> pure s
 
-  -- Eq  _ s a b     -> [a' == b' | a' <- eval a, b' <- eval b]
-  -- NEq _ s a b     -> [a' /= b' | a' <- eval a, b' <- eval b]
+  -- TODO better way to write these?
+  Eq _ SInteger x y -> [ x' == y' | x' <- eval x, y' <- eval y]
+  Eq _ SBoolean x y -> [ x' == y' | x' <- eval x, y' <- eval y]
+  Eq _ SByteStr x y -> [ x' == y' | x' <- eval x, y' <- eval y]
+
+  NEq _ SInteger x y -> [ x' /= y' | x' <- eval x, y' <- eval y]
+  NEq _ SBoolean x y -> [ x' /= y' | x' <- eval x, y' <- eval y]
+  NEq _ SByteStr x y -> [ x' /= y' | x' <- eval x, y' <- eval y]
+
   ITE _ a b c   -> eval a >>= \cond -> if cond then eval b else eval c
   _             -> empty
 

--- a/src/Syntax/TimeAgnostic.hs
+++ b/src/Syntax/TimeAgnostic.hs
@@ -256,7 +256,7 @@ instance Eq (Exp a t) where
   ByEnv _ a == ByEnv _ b = a == b
 
   Eq _ s a b == Eq _ s' c d = eqS s a s' c && eqS s b s' d
-  NEq _ s a b == Eq _ s' c d = eqS s a s' c && eqS s b s' d
+  NEq _ s a b == NEq _ s' c d = eqS s a s' c && eqS s b s' d
 
   ITE _ a b c == ITE _ d e f = a == d && b == e && c == f
   TEntry _ a t == TEntry _ b u = a == b && t == u

--- a/src/Syntax/TimeAgnostic.hs
+++ b/src/Syntax/TimeAgnostic.hs
@@ -142,6 +142,7 @@ deriving instance Show (StorageLocation t)
 instance Eq (StorageLocation t) where
   Loc s1 i1 == Loc s2 i2 = eqS s1 i1 s2 i2
 
+
 -- | References to items in storage, either as a map lookup or as a reading of
 -- a simple variable. The list argument is a list of indices; it has entries iff
 -- the item is referenced as a map lookup. The type is parametrized on a

--- a/src/Syntax/Types.hs
+++ b/src/Syntax/Types.hs
@@ -19,9 +19,9 @@ Description : Types that represent Act types, and functions and patterns to go b
 
 module Syntax.Types (module Syntax.Types) where
 
+import Data.Singletons
 import Data.ByteString    as Syntax.Types (ByteString)
 import Data.Type.Equality (TestEquality(..), (:~:)(..))
-import Data.Singletons
 import EVM.ABI            as Syntax.Types (AbiType(..))
 
 -- | Types of Act expressions
@@ -39,6 +39,8 @@ data SType (a :: ActType) where
   SByteStr :: SType AByteStr
 deriving instance Show (SType a)
 deriving instance Eq (SType a)
+
+type instance Sing = SType
 
 instance TestEquality SType where
   testEquality SInteger SInteger = Just Refl
@@ -59,7 +61,6 @@ type family TypeOf a where
   TypeOf 'ABoolean = Bool
   TypeOf 'AByteStr = ByteString
 
-
 actType :: AbiType -> ActType
 actType (AbiUIntType _)     = AInteger
 actType (AbiIntType  _)     = AInteger
@@ -69,3 +70,27 @@ actType (AbiBytesType n)    = if n <= 32 then AInteger else AByteStr
 actType AbiBytesDynamicType = AByteStr
 actType AbiStringType       = AByteStr
 actType _ = error "Syntax.Types.actType: TODO"
+
+
+-- type SomeType = SomeSing *
+
+-- toAct :: SType a -> ActType
+-- toAct SInteger = AInteger
+-- toAct SBoolean = ABoolean
+-- toAct SByteStr = AByteStr
+
+-- fromAct :: ActType -> SomeType
+-- fromAct AInteger = SomeSing SInteger
+-- fromAct ABoolean = SomeSing SBoolean
+-- fromAct AByteStr = SomeSing SByteStr
+
+-- -- | Pattern match on an 'ActType' is if it were an 'SType'.
+-- pattern FromAct :: () => SType a -> SomeType
+-- pattern FromAct t <- SomeSing t
+-- {-# COMPLETE FromAct #-}
+
+-- -- -- | Pattern match on an 'EVM.ABI.AbiType' is if it were an 'SType'.
+-- -- pattern FromAbi :: () => (SingI a, Typeable a) => SType a -> AbiType
+-- -- pattern FromAbi t <- (actType -> FromAct t)
+-- -- {-# COMPLETE FromAbi #-}
+

--- a/src/Syntax/Types.hs
+++ b/src/Syntax/Types.hs
@@ -72,25 +72,23 @@ actType AbiStringType       = AByteStr
 actType _ = error "Syntax.Types.actType: TODO"
 
 
--- type SomeType = SomeSing *
+someType :: ActType -> SomeType
+someType AInteger = SomeType SInteger
+someType ABoolean = SomeType SBoolean
+someType AByteStr = SomeType SByteStr
 
--- toAct :: SType a -> ActType
--- toAct SInteger = AInteger
--- toAct SBoolean = ABoolean
--- toAct SByteStr = AByteStr
 
--- fromAct :: ActType -> SomeType
--- fromAct AInteger = SomeSing SInteger
--- fromAct ABoolean = SomeSing SBoolean
--- fromAct AByteStr = SomeSing SByteStr
+data SomeType where
+  SomeType :: SType a -> SomeType
+  
+-- | Pattern match on an 'SomeType' is if it were an 'SType'.
+pattern FromSome :: SType a -> SomeType
+pattern FromSome t <- SomeType t
 
--- -- | Pattern match on an 'ActType' is if it were an 'SType'.
--- pattern FromAct :: () => SType a -> SomeType
--- pattern FromAct t <- SomeSing t
--- {-# COMPLETE FromAct #-}
+-- | Pattern match on an 'AbiType' is if it were an 'SType'.
+pattern FromAbi :: SType a -> AbiType
+pattern FromAbi t <- (someType . actType -> FromSome t)
 
--- -- -- | Pattern match on an 'EVM.ABI.AbiType' is if it were an 'SType'.
--- -- pattern FromAbi :: () => (SingI a, Typeable a) => SType a -> AbiType
--- -- pattern FromAbi t <- (actType -> FromAct t)
--- -- {-# COMPLETE FromAbi #-}
-
+-- | Pattern match on an 'ActType' is if it were an 'SType'.
+pattern FromAct :: SType a -> ActType
+pattern FromAct t <- (someType -> FromSome t)

--- a/src/Syntax/Types.hs
+++ b/src/Syntax/Types.hs
@@ -61,21 +61,26 @@ type family TypeOf a where
   TypeOf 'ABoolean = Bool
   TypeOf 'AByteStr = ByteString
 
-actType :: AbiType -> ActType
-actType (AbiUIntType _)     = AInteger
-actType (AbiIntType  _)     = AInteger
-actType AbiAddressType      = AInteger
-actType AbiBoolType         = ABoolean
-actType (AbiBytesType n)    = if n <= 32 then AInteger else AByteStr
-actType AbiBytesDynamicType = AByteStr
-actType AbiStringType       = AByteStr
-actType _ = error "Syntax.Types.actType: TODO"
+fromAbiType :: AbiType -> ActType
+fromAbiType (AbiUIntType _)     = AInteger
+fromAbiType (AbiIntType  _)     = AInteger
+fromAbiType AbiAddressType      = AInteger
+fromAbiType AbiBoolType         = ABoolean
+fromAbiType (AbiBytesType n)    = if n <= 32 then AInteger else AByteStr
+fromAbiType AbiBytesDynamicType = AByteStr
+fromAbiType AbiStringType       = AByteStr
+fromAbiType _ = error "Syntax.Types.actType: TODO"
 
 
 someType :: ActType -> SomeType
 someType AInteger = SomeType SInteger
 someType ABoolean = SomeType SBoolean
 someType AByteStr = SomeType SByteStr
+
+actType :: SType s -> ActType
+actType SInteger = AInteger
+actType SBoolean = ABoolean
+actType SByteStr = AByteStr
 
 
 data SomeType where
@@ -84,11 +89,14 @@ data SomeType where
 -- | Pattern match on an 'SomeType' is if it were an 'SType'.
 pattern FromSome :: SType a -> SomeType
 pattern FromSome t <- SomeType t
+{-# COMPLETE FromSome #-}
 
 -- | Pattern match on an 'AbiType' is if it were an 'SType'.
 pattern FromAbi :: SType a -> AbiType
-pattern FromAbi t <- (someType . actType -> FromSome t)
+pattern FromAbi t <- (someType . fromAbiType -> FromSome t)
+{-# COMPLETE FromAbi #-}
 
 -- | Pattern match on an 'ActType' is if it were an 'SType'.
 pattern FromAct :: SType a -> ActType
 pattern FromAct t <- (someType -> FromSome t)
+{-# COMPLETE FromAct #-}

--- a/src/Syntax/Types.hs
+++ b/src/Syntax/Types.hs
@@ -23,6 +23,8 @@ import Data.Tuple.Extra (dupe)
 import Data.Type.Equality (TestEquality(..))
 import Data.Typeable hiding (TypeRep,typeRep)
 import Type.Reflection
+import Data.ByteString (empty)
+
 
 import Data.ByteString    as Syntax.Types (ByteString)
 import EVM.ABI            as Syntax.Types (AbiType(..))
@@ -156,3 +158,13 @@ typeableInstance rep = withTypeable rep TypeableInstance
 pattern TypeRep :: forall (k :: *) (a :: k). () => Typeable @k a => TypeRep @k a
 pattern TypeRep <- (typeableInstance -> TypeableInstance)
   where TypeRep = typeRep
+
+
+acttyp :: Int -> ActType
+acttyp _ = SomeSing SBoolean
+
+
+typeToVal :: forall a. SType a -> a
+typeToVal SInteger = 1
+typeToVal SBoolean = True
+typeToVal SByteStr = empty

--- a/src/Syntax/Types.hs
+++ b/src/Syntax/Types.hs
@@ -52,34 +52,21 @@ instance Show (SType a) where
 
 type instance Sing = SType
 
--- | Singleton types of the types understood by proving tools.
-data VSType a where
-  VSInteger :: VSType Integer
-  VSBoolean :: VSType Bool
-  VSByteStr :: VSType ByteString
-deriving instance Eq (VSType a)
-
-type instance Sing = VSType
-
-instance TestEquality VSType where
-  testEquality SType SType = eqT
--- instance TestEquality SType where
---   testEquality SInteger SInteger = Just Refl
---   testEquality SBoolean SBoolean = Just Refl
---   testEquality SByteStr SByteStr = Just Refl
---   testEquality _ _ = Nothing
-
-
--- | Compare equality of two things parametrized by types which have singletons.
-eqS :: forall (a :: *) (b :: *) f t. (SingI a, SingI b, Eq (f a t)) => f a t -> f b t -> Bool
-eqS fa fb = maybe False (\Refl -> fa == fb) $ testEquality (sing @a) (sing @b)
+instance TestEquality SType where
+  testEquality SInteger SInteger = Just Refl
+  testEquality SBoolean SBoolean = Just Refl
+  testEquality SByteStr SByteStr = Just Refl
+  testEquality _ _ = Nothing
 
 
 -- -- | Compare equality of two things parametrized by types which have singletons.
--- eqS :: forall (a :: ActType) (b :: ActType) f t. (Eq (f a t), SingI a, SingI b) => f a t -> f b t -> Bool
--- eqS ea eb = case testEquality (sing @a) (sing @b) of
---                        Just Refl -> ea == eb
---                        _ -> False
+-- eqS :: forall (a :: *) (b :: *) f t. (SingI a, SingI b, Eq (f a t)) => f a t -> f b t -> Bool
+-- eqS fa fb = maybe False (\Refl -> fa == fb) $ testEquality (sing @a) (sing @b)
+-- | Compare equality of two things parametrized by types which have singletons.
+eqS :: forall (a :: ActType) (b :: ActType) f t. (Eq (f a t), SingI a, SingI b) => f a t -> f b t -> Bool
+eqS ea eb = case testEquality (sing @a) (sing @b) of
+                       Just Refl -> ea == eb
+                       _ -> False
 
 -- Defines which singleton to retreive when we only have the type, not the
 -- actual singleton.
@@ -133,3 +120,10 @@ pattern FromAbi t <- (someType . fromAbiType -> FromSome t)
 pattern FromAct ::() => (SingI a) => SType a -> ActType
 pattern FromAct t <- (someType -> FromSome t)
 {-# COMPLETE FromAct #-}
+
+
+-- | Helper pattern to retrieve the 'SingI' instances of the type
+-- represented by an 'SType'.
+pattern SType :: () => (SingI a) => SType a
+pattern SType <- Sing
+{-# COMPLETE SType #-}

--- a/src/Syntax/Types.hs
+++ b/src/Syntax/Types.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
@@ -18,153 +19,46 @@ Description : Types that represent Act types, and functions and patterns to go b
 
 module Syntax.Types (module Syntax.Types) where
 
-import Data.Singletons
-import Data.Tuple.Extra (dupe)
-import Data.Type.Equality (TestEquality(..))
-import Data.Typeable hiding (TypeRep,typeRep)
-import Type.Reflection
-import Data.ByteString (empty)
-
-
 import Data.ByteString    as Syntax.Types (ByteString)
+import Data.Type.Equality (TestEquality(..), (:~:)(..))
 import EVM.ABI            as Syntax.Types (AbiType(..))
 
--- | Singleton types of the types understood by proving tools.
-data SType a where
-  SInteger :: SType Integer
-  SBoolean :: SType Bool
-  SByteStr :: SType ByteString
-deriving instance Eq (SType a)
+-- | Types of Act expressions
+data ActType
+  = AInteger
+  | ABoolean
+  | AByteStr
 
-instance Show (SType a) where
-  show = \case
-    SInteger -> "int"
-    SBoolean -> "bool"
-    SByteStr -> "bytestring"
+-- | Singleton runtime witness for Act types
+-- Sometimes we need to examine type tags at runime. Tagging structures
+-- with this type will let us do that. 
+data SType (a :: ActType) where
+  SInteger :: SType AInteger
+  SBoolean :: SType ABoolean
+  SByteStr :: SType AByteStr
+deriving instance Show (SType a)
+
 
 instance TestEquality SType where
-  testEquality SType SType = eqT
+  testEquality SInteger SInteger = Just Refl
+  testEquality SBoolean SBoolean = Just Refl
+  testEquality SByteStr SByteStr = Just Refl
+  testEquality _ _ = Nothing
 
--- | Compare equality of two things parametrized by types which have singletons.
-eqS :: forall (a :: *) (b :: *) f t. (SingI a, SingI b, Eq (f a t)) => f a t -> f b t -> Bool
-eqS fa fb = maybe False (\Refl -> fa == fb) $ testEquality (sing @a) (sing @b)
+-- | Reflection of an Act type into a haskell type. Usefull to define
+-- the result type of the evaluation function.
+type family TypeOf a where
+  TypeOf 'AInteger = Integer
+  TypeOf 'ABoolean = Bool
+  TypeOf 'AByteStr = ByteString
 
--- | For our purposes, the singleton of a type @a@ is always @'SType' a@.
--- We need this to be able to use 'SomeSing' when implementing 'ActType'.
-
--- Note that even though there only exist three different 'SType', this does
--- not mean that the type family is partial. It simply means that the resulting
--- type is uninhabited if the argument is neither 'Integer', 'Bool' nor
--- 'ByteString'.
-type instance Sing = SType
-
--- Defines which singleton to retreive when we only have the type, not the
--- actual singleton.
-instance SingI Integer    where sing = SInteger
-instance SingI Bool       where sing = SBoolean
-instance SingI ByteString where sing = SByteStr
-
--- | A non-indexed type whose inhabitants represent the types understood
--- by proving tools. Implemented by an existentially quantified 'SType',
--- but it is recommended to use the patterns 'Syntax.Types.Integer', 'Boolean'
--- and 'ByteStr' whenever constructing or matching on these.
-type ActType = SomeSing *
-
-pattern Integer :: ActType
-pattern Integer = SomeSing SInteger
-
-pattern Boolean :: ActType
-pattern Boolean = SomeSing SBoolean
-
-pattern ByteStr :: ActType
-pattern ByteStr = SomeSing SByteStr
-
-{-# COMPLETE Integer, Boolean, ByteStr #-}
-
-class HasType a t where
-  getType :: a -> SType t
 
 actType :: AbiType -> ActType
-actType (AbiUIntType _)     = Integer
-actType (AbiIntType  _)     = Integer
-actType AbiAddressType      = Integer
-actType AbiBoolType         = Boolean
-actType (AbiBytesType n)    = if n <= 32 then Integer else ByteStr
-actType AbiBytesDynamicType = ByteStr
-actType AbiStringType       = ByteStr
---actType (AbiArrayDynamicType a) =
---actType (AbiArrayType        Int AbiType
---actType (AbiTupleType        (Vector AbiType)
+actType (AbiUIntType _)     = AInteger
+actType (AbiIntType  _)     = AInteger
+actType AbiAddressType      = AInteger
+actType AbiBoolType         = ABoolean
+actType (AbiBytesType n)    = if n <= 32 then AInteger else AByteStr
+actType AbiBytesDynamicType = AByteStr
+actType AbiStringType       = AByteStr
 actType _ = error "Syntax.Types.actType: TODO"
-
--- | Pattern match on an 'EVM.ABI.AbiType' is if it were an 'SType'.
-pattern FromAbi :: () => (SingI a, Typeable a) => SType a -> AbiType
-pattern FromAbi t <- (actType -> FromAct t)
-{-# COMPLETE FromAbi #-}
-
--- | Pattern match on an 'ActType' is if it were an 'SType'.
-pattern FromAct :: () => (SingI a, Typeable a) => SType a -> ActType
-pattern FromAct t <- SomeSing t@SType
-{-# COMPLETE FromAct #-}
-
--- | Helper pattern to retrieve the 'Typeable' and 'SingI' instances of the type
--- represented by an 'SType'.
-pattern SType :: () => (SingI a, Typeable a) => SType a
-pattern SType <- (dupe -> (Sing, stypeRep -> TypeRep))
-{-# COMPLETE SType #-}
-
--- | Allows us to retrieve the 'TypeRep' of any 'SType', which in turn can be used
--- to retrieve the 'Typeable' instance.
-stypeRep :: SType a -> TypeRep a
-stypeRep = \case
-  SInteger -> typeRep
-  SBoolean -> typeRep
-  SByteStr -> typeRep
-
--- Everything below will be added to base 4.17 but for now we need it here.
--- See https://gitlab.haskell.org/ghc/ghc/-/commit/d3ef2dc2bdfec457d5e0973f3e8f3e92767c16af#786588e27bcbc2a8360d2d0d3b2ce1d075797ffb_232_263
-
--- | A 'TypeableInstance' wraps up a 'Typeable' instance for explicit
--- handling. For internal use: for defining 'TypeRep' pattern.
-type TypeableInstance :: forall k. k -> *
-data TypeableInstance a where
- TypeableInstance :: Typeable a => TypeableInstance a
-
--- | Get a reified 'Typeable' instance from an explicit 'TypeRep'.
---
--- For internal use: for defining 'TypeRep' pattern.
-typeableInstance :: forall (k :: *) (a :: k). TypeRep a -> TypeableInstance a
-typeableInstance rep = withTypeable rep TypeableInstance
-
--- | A explicitly bidirectional pattern synonym to construct a
--- concrete representation of a type.
---
--- As an __expression__: Constructs a singleton @TypeRep a@ given a
--- implicit 'Typeable a' constraint:
---
--- @
--- TypeRep @a :: Typeable a => TypeRep a
--- @
---
--- As a __pattern__: Matches on an explicit @TypeRep a@ witness bringing
--- an implicit @Typeable a@ constraint into scope.
---
--- @
--- f :: TypeRep a -> ..
--- f TypeRep = {- Typeable a in scope -}
--- @
---
--- @since 4.17.0.0
-pattern TypeRep :: forall (k :: *) (a :: k). () => Typeable @k a => TypeRep @k a
-pattern TypeRep <- (typeableInstance -> TypeableInstance)
-  where TypeRep = typeRep
-
-
-acttyp :: Int -> ActType
-acttyp _ = SomeSing SBoolean
-
-
-typeToVal :: forall a. SType a -> a
-typeToVal SInteger = 1
-typeToVal SBoolean = True
-typeToVal SByteStr = empty

--- a/src/Syntax/Types.hs
+++ b/src/Syntax/Types.hs
@@ -32,7 +32,7 @@ data ActType
 
 -- | Singleton runtime witness for Act types
 -- Sometimes we need to examine type tags at runime. Tagging structures
--- with this type will let us do that. 
+-- with this type will let us do that.
 data SType (a :: ActType) where
   SInteger :: SType AInteger
   SBoolean :: SType ABoolean
@@ -53,6 +53,12 @@ eqS :: forall a b f t. Eq (f a t) => SType a -> f a t -> SType b -> f b t -> Boo
 eqS sa ea sb eb = case testEquality sa sb of
                        Just Refl -> ea == eb
                        _ -> False
+
+-- Defines which singleton to retreive when we only have the type, not the
+-- actual singleton.
+instance SingI 'AInteger where sing = SInteger
+instance SingI 'ABoolean where sing = SBoolean
+instance SingI 'AByteStr where sing = SByteStr
 
 -- | Reflection of an Act type into a haskell type. Usefull to define
 -- the result type of the evaluation function.
@@ -84,19 +90,19 @@ actType SByteStr = AByteStr
 
 
 data SomeType where
-  SomeType :: SType a -> SomeType
-  
+  SomeType :: SingI a => SType a -> SomeType
+
 -- | Pattern match on an 'SomeType' is if it were an 'SType'.
-pattern FromSome :: SType a -> SomeType
+pattern FromSome :: () => (SingI a) => SType a -> SomeType
 pattern FromSome t <- SomeType t
 {-# COMPLETE FromSome #-}
 
 -- | Pattern match on an 'AbiType' is if it were an 'SType'.
-pattern FromAbi :: SType a -> AbiType
+pattern FromAbi :: () => (SingI a) => SType a -> AbiType
 pattern FromAbi t <- (someType . fromAbiType -> FromSome t)
 {-# COMPLETE FromAbi #-}
 
 -- | Pattern match on an 'ActType' is if it were an 'SType'.
-pattern FromAct :: SType a -> ActType
+pattern FromAct ::() => (SingI a) => SType a -> ActType
 pattern FromAct t <- (someType -> FromSome t)
 {-# COMPLETE FromAct #-}

--- a/src/Syntax/Types.hs
+++ b/src/Syntax/Types.hs
@@ -24,11 +24,6 @@ import Data.ByteString    as Syntax.Types (ByteString)
 import Data.Type.Equality (TestEquality(..), (:~:)(..))
 import EVM.ABI            as Syntax.Types (AbiType(..))
 
-import Data.Tuple.Extra (dupe)
-import Data.Type.Equality (TestEquality(..))
-import Data.Typeable hiding (TypeRep,typeRep)
-import Type.Reflection
-
 -- | Types of Act expressions
 data ActType
   = AInteger

--- a/src/Syntax/Types.hs
+++ b/src/Syntax/Types.hs
@@ -21,6 +21,7 @@ module Syntax.Types (module Syntax.Types) where
 
 import Data.ByteString    as Syntax.Types (ByteString)
 import Data.Type.Equality (TestEquality(..), (:~:)(..))
+import Data.Singletons
 import EVM.ABI            as Syntax.Types (AbiType(..))
 
 -- | Types of Act expressions
@@ -37,13 +38,19 @@ data SType (a :: ActType) where
   SBoolean :: SType ABoolean
   SByteStr :: SType AByteStr
 deriving instance Show (SType a)
-
+deriving instance Eq (SType a)
 
 instance TestEquality SType where
   testEquality SInteger SInteger = Just Refl
   testEquality SBoolean SBoolean = Just Refl
   testEquality SByteStr SByteStr = Just Refl
   testEquality _ _ = Nothing
+
+-- | Compare equality of two things parametrized by types which have singletons.
+eqS :: forall a b f t. Eq (f a t) => SType a -> f a t -> SType b -> f b t -> Bool
+eqS sa ea sb eb = case testEquality sa sb of
+                       Just Refl -> ea == eb
+                       _ -> False
 
 -- | Reflection of an Act type into a haskell type. Usefull to define
 -- the result type of the evaluation function.

--- a/src/Syntax/Types.hs
+++ b/src/Syntax/Types.hs
@@ -37,8 +37,13 @@ data SType (a :: ActType) where
   SInteger :: SType AInteger
   SBoolean :: SType ABoolean
   SByteStr :: SType AByteStr
-deriving instance Show (SType a)
 deriving instance Eq (SType a)
+
+instance Show (SType a) where
+  show = \case
+    SInteger -> "int"
+    SBoolean -> "bool"
+    SByteStr -> "bytestring"
 
 type instance Sing = SType
 

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -131,7 +131,7 @@ mkEnv contract store decls = Env
   , calldata = abiVars
   }
  where
-   abiVars = Map.fromList $ map (\(Decl typ var) -> (var, actType typ)) decls
+   abiVars = Map.fromList $ map (\(Decl typ var) -> (var, fromAbiType typ)) decls
 
 -- checks a transition given a typing of its storage variables
 splitBehaviour :: Store -> U.RawBehaviour -> Err [Claim]
@@ -359,7 +359,7 @@ checkExpr env typ e = case (typ, e) of
   (SInteger, U.EMod    p v1 v2) -> Mod p <$> checkExpr env SInteger v1 <*> checkExpr env SInteger v2
   (SInteger, U.IntLit  p v1 )   -> pure $ LitInt  p v1
   -- Control
-  (typ, U.EITE p v1 v2 v3) -> ITE p <$> checkExpr env SBoolean v1 <*> checkExpr env typ v2 <*> checkExpr env typ v3
+  (_, U.EITE p v1 v2 v3) -> ITE p <$> checkExpr env SBoolean v1 <*> checkExpr env typ v2 <*> checkExpr env typ v3
   -- Environment variables
   (SInteger, U.EnvExp p v1) -> case lookup v1 defaultStore of
     Just AInteger -> pure $ IntEnv p v1

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -383,7 +383,6 @@ inferExpr env@Env{contract,store,calldata} expr = case expr of
 
 -- | Check the type of an expression and construct a typed expression
 checkExpr :: Env -> U.Expr -> SType a -> Err (Exp a)
-checkExpr env expr typ = <*> inferExpr env expr
 -- Boolean expressions
 checkExpr env expr SBoolean = case expr of
   U.ENot    p v1    -> Neg  p <$> checkExpr env v1 SBoolean 

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -35,6 +35,8 @@ import qualified Syntax.Untyped as U
 import Syntax.Typed
 import Error
 
+import Data.Type.Equality (TestEquality(..))
+
 type Err = Error String
 
 -- | Main typechecking function.
@@ -329,16 +331,15 @@ checkAbiExpr env e (FromAbi typ) = TExp typ <$> checkExpr env typ e
 
 -- | Attempt to typecheck an untyped expression as any possible type.
 typedExp :: Typeable t => Env -> U.Expr -> Err (TypedExp t)
-typedExp env e = fromMaybe (error $ "Internal error: Type.typedExp. Expr: " <> show e)
-                 $ notAtPosn (getPosn e)
-                 [ TExp SInteger <$> checkExpr env SInteger e
-                 , TExp SBoolean <$> checkExpr env SBoolean e
-                 , TExp SByteStr <$> checkExpr env SByteStr e
-                 ]
+typedExp env e = findSuccess (throw (getPosn e, "Cannot find a valid type for expression " <> show e))
+                   [ TExp SInteger <$> checkExpr env SInteger e
+                   , TExp SBoolean <$> checkExpr env SBoolean e
+                   , TExp SByteStr <$> checkExpr env SByteStr e
+                   ]
 
 -- | Check the type of an expression and construct a typed expression
 checkExpr :: forall a t. Typeable t => Env -> SType a -> U.Expr -> Err (Exp a t)
-checkExpr env typ e = case (typ, e) of
+checkExpr env@Env{contract,store,calldata} typ e = case (typ, e) of
   -- Boolean expressions
   (SBoolean, U.ENot    p v1)    -> Neg  p <$> checkExpr env SBoolean v1
   (SBoolean, U.EAnd    p v1 v2) -> And  p <$> checkExpr env SBoolean v1 <*> checkExpr env SBoolean v2
@@ -348,8 +349,8 @@ checkExpr env typ e = case (typ, e) of
   (SBoolean, U.ELEQ    p v1 v2) -> LEQ p  <$> checkExpr env SInteger v1 <*> checkExpr env SInteger v2
   (SBoolean, U.EGEQ    p v1 v2) -> GEQ p  <$> checkExpr env SInteger v1 <*> checkExpr env SInteger v2
   (SBoolean, U.EGT     p v1 v2) -> GT  p  <$> checkExpr env SInteger v1 <*> checkExpr env SInteger v2
-  (SBoolean, U.EEq     p v1 v2) -> polycheck p env Eq v1 v2
-  (SBoolean, U.ENeq    p v1 v2) -> polycheck p env NEq v1 v2
+  (SBoolean, U.EEq     p v1 v2) -> polycheck p Eq v1 v2
+  (SBoolean, U.ENeq    p v1 v2) -> polycheck p NEq v1 v2
   (SBoolean, U.BoolLit p v1)    -> pure $ LitBool p v1
   -- Arithemetic expressions
   (SInteger, U.EAdd    p v1 v2) -> Add p <$> checkExpr env SInteger v1 <*> checkExpr env SInteger v2
@@ -371,46 +372,44 @@ checkExpr env typ e = case (typ, e) of
     Just AByteStr -> pure $ ByEnv p v1
     _            -> throw (p, "Unknown environment variable " <> show v1)
   -- Variable references
-  (_, U.EUTEntry   p name es) -> checkEntry p env Neither name typ es
-  (_, U.EPreEntry  p name es) -> checkEntry p env Pre name typ es
-  (_, U.EPostEntry p name es) -> checkEntry p env Post name typ es
+  (_, U.EUTEntry   p name es) -> checkEntry p Neither name es
+  (_, U.EPreEntry  p name es) -> checkEntry p Pre name es
+  (_, U.EPostEntry p name es) -> checkEntry p Post name es
   -- TODO other error for unimplemented
   _ -> throw (getPosn e,"Type mismatch. Expression " <> show e <> " does not have type " <> show typ)
 
-polycheck :: Typeable t => Pn -> Env -> (forall y. Pn -> SType y -> Exp y t -> Exp y t -> Exp x t) -> U.Expr -> U.Expr -> Err (Exp x t)
-polycheck pn env cons e1 e2 = fromMaybe (error $ "Internal error: Type.polycheck. Expr1: " <> show e1)
-  $ notAtPosn (getPosn e1)
-  [ cons pn SInteger <$> checkExpr env SInteger e1 <*> checkExpr env SInteger e2
-  , cons pn SBoolean <$> checkExpr env SBoolean e1 <*> checkExpr env SBoolean e2
-  , cons pn SByteStr <$> checkExpr env SByteStr e1 <*> checkExpr env SByteStr e2
-  ]
+  where 
+    polycheck :: Pn -> (forall y. Pn -> SType y -> Exp y t -> Exp y t -> Exp x t) -> U.Expr -> U.Expr -> Err (Exp x t)
+    polycheck pn cons e1 e2 = findSuccess (throw (getPosn e1, "Cannot match the type of expression " <> show e1 <> " with expression " <> show e2))
+      [ cons pn SInteger <$> checkExpr env SInteger e1 <*> checkExpr env SInteger e2
+      , cons pn SBoolean <$> checkExpr env SBoolean e1 <*> checkExpr env SBoolean e2
+      , cons pn SByteStr <$> checkExpr env SByteStr e1 <*> checkExpr env SByteStr e2
+      ]
 
+    -- Try to construct a reference to a calldata variable or an item in storage.
+    checkEntry :: forall t0. Typeable t0 => Pn -> Time t0 -> Id -> [U.Expr] -> Err (Exp a t)
+    checkEntry pn timing name es = case (Map.lookup name store, Map.lookup name calldata) of
+      (Nothing, Nothing) -> throw (pn, "Unknown variable " <> name)
+      (Just _, Just _)   -> throw (pn, "Ambiguous variable " <> name)
+      (Nothing, Just (FromAct varType)) ->
+        if isTimed timing then throw (pn, "Calldata var cannot be pre/post")
+        else Var pn typ name <$ checkEq pn typ varType
+      (Just (StorageValue (FromAbi varTyp)), Nothing)      -> makeEntry typ [] <* checkEq pn typ varTyp
+      (Just (StorageMapping ts (FromAbi varTyp)), Nothing) -> makeEntry typ (NonEmpty.toList ts) <* checkEq pn typ varTyp
+      where
+        makeEntry :: SType a -> [AbiType] -> Err (Exp a t)
+        makeEntry entryType ts = checkTime <*> (TEntry pn timing . Item entryType contract name <$> checkIxs pn env es ts)
+  
+        checkTime :: Err (Exp x t0 -> Exp x t)
+        checkTime = case eqT @t @t0 of
+          Just Refl -> pure id
+          Nothing   -> throw (pn, (tail . show $ typeRep @t) <> " variable needed here")
 
+      
 checkEq :: forall a b. Pn -> SType a -> SType b -> Err ()
-checkEq _ SInteger SInteger = pure ()
-checkEq _ SBoolean SBoolean = pure ()
-checkEq _ SByteStr SByteStr = pure ()
-checkEq pn t1 t2 = throw (pn, "Type " <> show t1 <> " should match type " <> show t2)
-
--- XXX why different t t0
--- Try to construct a reference to a calldata variable or an item in storage.
-checkEntry :: forall t a t0. Typeable t => Typeable t0 => Pn -> Env -> Time t0 -> Id -> SType a -> [U.Expr] -> Err (Exp a t)
-checkEntry pn env@Env{contract,store,calldata} timing name typ es = case (Map.lookup name store, Map.lookup name calldata) of
-  (Nothing, Nothing) -> throw (pn, "Unknown variable " <> name)
-  (Just _, Just _)   -> throw (pn, "Ambiguous variable " <> name)
-  (Nothing, Just (FromAct varType)) ->
-    if isTimed timing then throw (pn, "Calldata var cannot be pre/post")
-    else Var pn typ name <$ checkEq pn typ varType
-  (Just (StorageValue (FromAbi varTyp)), Nothing)      -> makeEntry typ [] <* checkEq pn typ varTyp
-  (Just (StorageMapping ts (FromAbi varTyp)), Nothing) -> makeEntry typ (NonEmpty.toList ts) <* checkEq pn typ varTyp
+checkEq p t1 t2 = maybe err (\Refl -> pure ()) $  testEquality t1 t2
   where
-    makeEntry :: SType a -> [AbiType] -> Err (Exp a t)
-    makeEntry entryType ts = checkTime <*> (TEntry pn timing . Item entryType contract name <$> checkIxs pn env es ts)
-
-    checkTime :: Err (Exp x t0 -> Exp x t)
-    checkTime = case eqT @t @t0 of
-      Just Refl -> pure id
-      Nothing   -> throw (pn, (tail . show $ typeRep @t) <> " variable needed here")
+    err = (throw (p, "Type " <> show t1 <> " should match type " <> show t2)) 
 
 
 -- | Checks that there are as many expressions as expected by the types,

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -357,6 +357,7 @@ checkExpr env typ e = case (typ, e) of
   (SInteger, U.EMul    p v1 v2) -> Mul p <$> checkExpr env SInteger v1 <*> checkExpr env SInteger v2
   (SInteger, U.EDiv    p v1 v2) -> Div p <$> checkExpr env SInteger v1 <*> checkExpr env SInteger v2
   (SInteger, U.EMod    p v1 v2) -> Mod p <$> checkExpr env SInteger v1 <*> checkExpr env SInteger v2
+  (SInteger, U.EExp    p v1 v2) -> Exp p <$> checkExpr env SInteger v1 <*> checkExpr env SInteger v2
   (SInteger, U.IntLit  p v1 )   -> pure $ LitInt  p v1
   -- Control
   (_, U.EITE p v1 v2 v3) -> ITE p <$> checkExpr env SBoolean v1 <*> checkExpr env typ v2 <*> checkExpr env typ v3

--- a/src/test/Test.hs
+++ b/src/test/Test.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
 
 module Main where
 
@@ -125,17 +126,17 @@ mkDecls :: Names -> ExpoGen [Decl]
 mkDecls (Names ints bools bytes) = mapM mkDecl names
   where
     mkDecl (n, typ) = ((flip Decl) n) <$> (genType typ)
-    names = prepare Integer ints ++ prepare Boolean bools ++ prepare ByteStr bytes
+    names = prepare AInteger ints ++ prepare ABoolean bools ++ prepare AByteStr bytes
     prepare typ ns = (,typ) <$> ns
 
 
 genType :: ActType -> ExpoGen AbiType
 genType typ = case typ of
   AInteger -> oneof [ AbiUIntType <$> validIntSize
-                   , AbiIntType <$> validIntSize
-                   , return AbiAddressType
-                   , AbiBytesType <$> validBytesSize
-                   ]
+                    , AbiIntType <$> validIntSize
+                    , return AbiAddressType
+                    , AbiBytesType <$> validBytesSize
+                    ]
   ABoolean -> return AbiBoolType
   AByteStr -> return AbiStringType
                    --, return AbiBytesDynamicType -- TODO: needs frontend support
@@ -155,22 +156,22 @@ genTypedExp names n = oneof
 
 -- TODO: literals, cat slice, ITE, storage, ByStr
 genExpBytes :: Names -> Int -> ExpoGen (Exp AByteStr)
-genExpBytes names _ = _Var <$> selectName ByteStr names
+genExpBytes names _ = _Var <$> selectName AByteStr names
 
 -- TODO: ITE, storage
 genExpBool :: Names -> Int -> ExpoGen (Exp ABoolean)
 genExpBool names 0 = oneof
-  [ _Var <$> selectName Boolean names
+  [ _Var <$> selectName ABoolean names
   , LitBool nowhere <$> liftGen arbitrary
   ]
 genExpBool names n = oneof
   [ liftM2 (And nowhere) subExpBool subExpBool
   , liftM2 (Or nowhere) subExpBool subExpBool
   , liftM2 (Impl nowhere) subExpBool subExpBool
-  , liftM2 (Eq nowhere) subExpInt subExpInt
-  , liftM2 (Eq nowhere) subExpBool subExpBool
-  , liftM2 (Eq nowhere) subExpBytes subExpBytes
-  , liftM2 (NEq nowhere) subExpInt subExpInt
+  , liftM2 (Eq nowhere SInteger) subExpInt subExpInt
+  , liftM2 (Eq nowhere SBoolean) subExpBool subExpBool
+  , liftM2 (Eq nowhere SByteStr) subExpBytes subExpBytes
+  , liftM2 (NEq nowhere SInteger) subExpInt subExpInt
   , liftM2 (LT nowhere) subExpInt subExpInt
   , liftM2 (LEQ nowhere) subExpInt subExpInt
   , liftM2 (GEQ nowhere) subExpInt subExpInt
@@ -186,7 +187,7 @@ genExpBool names n = oneof
 genExpInt :: Names -> Int -> ExpoGen (Exp AInteger)
 genExpInt names 0 = oneof
   [ LitInt nowhere <$> liftGen arbitrary
-  , _Var <$> selectName Integer names
+  , _Var <$> selectName AInteger names
   , return $ IntEnv nowhere Caller
   , return $ IntEnv nowhere Callvalue
   , return $ IntEnv nowhere Calldepth

--- a/src/test/Test.hs
+++ b/src/test/Test.hs
@@ -131,13 +131,13 @@ mkDecls (Names ints bools bytes) = mapM mkDecl names
 
 genType :: ActType -> ExpoGen AbiType
 genType typ = case typ of
-  Integer -> oneof [ AbiUIntType <$> validIntSize
+  AInteger -> oneof [ AbiUIntType <$> validIntSize
                    , AbiIntType <$> validIntSize
                    , return AbiAddressType
                    , AbiBytesType <$> validBytesSize
                    ]
-  Boolean -> return AbiBoolType
-  ByteStr -> return AbiStringType
+  ABoolean -> return AbiBoolType
+  AByteStr -> return AbiStringType
                    --, return AbiBytesDynamicType -- TODO: needs frontend support
 
   where
@@ -220,9 +220,9 @@ genExpInt names n = do
 selectName :: ActType -> Names -> ExpoGen String
 selectName typ (Names ints bools bytes) = do
   let names = case typ of
-                Integer -> ints
-                Boolean -> bools
-                ByteStr -> bytes
+                AInteger -> ints
+                ABoolean -> bools
+                AByteStr -> bytes
   idx <- elements [0..((length names)-1)]
   return $ names!!idx
 

--- a/src/test/Test.hs
+++ b/src/test/Test.hs
@@ -154,11 +154,11 @@ genTypedExp names n = oneof
 
 
 -- TODO: literals, cat slice, ITE, storage, ByStr
-genExpBytes :: Names -> Int -> ExpoGen (Exp ByteString)
+genExpBytes :: Names -> Int -> ExpoGen (Exp AByteStr)
 genExpBytes names _ = _Var <$> selectName ByteStr names
 
 -- TODO: ITE, storage
-genExpBool :: Names -> Int -> ExpoGen (Exp Bool)
+genExpBool :: Names -> Int -> ExpoGen (Exp ABoolean)
 genExpBool names 0 = oneof
   [ _Var <$> selectName Boolean names
   , LitBool nowhere <$> liftGen arbitrary
@@ -183,7 +183,7 @@ genExpBool names n = oneof
 
 
 -- TODO: storage
-genExpInt :: Names -> Int -> ExpoGen (Exp Integer)
+genExpInt :: Names -> Int -> ExpoGen (Exp AInteger)
 genExpInt names 0 = oneof
   [ LitInt nowhere <$> liftGen arbitrary
   , _Var <$> selectName Integer names

--- a/tests/invariants/pass/amm-full.act
+++ b/tests/invariants/pass/amm-full.act
@@ -1,0 +1,55 @@
+constructor of Token
+interface constructor(uint _supply)
+
+creates
+    mapping(address => uint) balanceOf :=  [CALLER := _supply]
+
+constructor of Amm
+interface constructor(Token t0, Token t1)
+
+creates
+
+    Token token0 := t0
+    Token token1 := t1
+
+invariants
+
+    pre(token0.balanceOf[THIS]) * pre(token1.balanceOf[THIS]) <= post(token0.balanceOf[THIS]) * post(token1.balanceOf[THIS])
+
+behaviour swap0 of Amm
+interface swap0(uint256 amt)
+
+iff in range uint256
+
+    token0.balanceOf[CALLER] - amt
+    token0.balanceOf[THIS] + amt
+    token0.balanceOf[THIS] * token1.balanceOf[THIS]
+    (token1.balanceOf[THIS] - ((token0.balanceOf[THIS] * token1.balanceOf[THIS]) / (token0.balanceOf[THIS] + amt)))
+    token1.balanceOf[CALLER] + (token1.balanceOf[THIS] - ((token0.balanceOf[THIS] * token1.balanceOf[THIS]) / (token0.balanceOf[THIS] + amt)))
+
+storage
+
+    token0.balanceOf[CALLER] => token0.balanceOf[CALLER] - amt
+    token0.balanceOf[THIS]   => token0.balanceOf[THIS] + amt
+
+    token1.balanceOf[THIS]   => (token0.balanceOf[THIS] * token1.balanceOf[THIS]) / (token0.balanceOf[THIS] + amt)
+    token1.balanceOf[CALLER] => token1.balanceOf[CALLER] + (token1.balanceOf[THIS] - ((token0.balanceOf[THIS] * token1.balanceOf[THIS]) / (token0.balanceOf[THIS] + amt)))
+
+behaviour swap1 of Amm
+interface swap1(uint256 amt)
+
+iff in range uint256
+
+    token0.balanceOf[CALLER] - amt
+    token0.balanceOf[THIS] + amt
+    token0.balanceOf[THIS] * token1.balanceOf[THIS]
+    (token1.balanceOf[THIS] - ((token0.balanceOf[THIS] * token1.balanceOf[THIS]) / (token0.balanceOf[THIS] + amt)))
+    token1.balanceOf[CALLER] + (token1.balanceOf[THIS] - ((token0.balanceOf[THIS] * token1.balanceOf[THIS]) / (token0.balanceOf[THIS] + amt)))
+
+storage
+
+    token1.balanceOf[CALLER] => token1.balanceOf[CALLER] - amt
+    token1.balanceOf[THIS]   => token1.balanceOf[THIS] + amt
+
+    token0.balanceOf[THIS]   => (token0.balanceOf[THIS] * token1.balanceOf[THIS]) / (token0.balanceOf[THIS] + amt)
+    token0.balanceOf[CALLER] => token0.balanceOf[CALLER] + (token0.balanceOf[THIS] - ((token0.balanceOf[THIS] * token1.balanceOf[THIS]) / (token1.balanceOf[THIS] + amt)))


### PR DESCRIPTION
This PR rewrites the type checker so that it doesn't rely on Haskell type introspection (i.e., eqT). Since we plan to add custom contract types to the language this approach wouldn't let us type check contract expressions. 

It also redefines some of the Act type machinery in Syntax/Types.hs to use data kinds instead of Haskell types as indices.
