### PR TITLE
No filtering out variables from environment

### DIFF
--- a/doc/src/language.md
+++ b/doc/src/language.md
@@ -233,23 +233,3 @@ ensures
 
    x == _x
 ```
-
-## Referencing Storage Variables
-
-Storage locations that are read and used in other expressions must be declared in a storage block.
-
-Some examples:
-
-```act
-storage
-  x => y
-  y
-```
-
-```act
-storage
-  x
-  y
-
-returns x + y
-``


### PR DESCRIPTION
Removes filtering out variables from the environment that do not appear at the LHS of storage update declarations.

The main reason for this is that the strategy for removing variables with contract types was wrong, so it is a prerequisite for an upcoming PR that add support for contract types. 

Note that now we lift the restriction that storage variables that are used in storage update declaration have to be explicitly mentioned in the storage updated declarations. 