### PR TITLE
Cycle detection in constructor call graphs

### DIFF
--- a/src/Error.hs
+++ b/src/Error.hs
@@ -35,6 +35,10 @@ throw msg = Failure [msg]
 assert :: (Pn, e) -> Bool -> Error e ()
 assert err b = if b then pure () else throw err
 
+foldValidation :: (b -> a -> Error err b) -> b -> [a] -> Error err b
+foldValidation _ b [] = pure b
+foldValidation f b (a:as) = f b a `bindValidation` \b' -> foldValidation f b' as 
+
 infixr 1 <==<, >==>
 
 -- Like 'Control.Monad.(>=>)' but allows us to chain error-prone

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -469,7 +469,7 @@ checkExpr env@Env{constructors} typ e = case (typ, e) of
     checkTime (getPosEntry entry) <*> (TEntry (getPosEntry entry) Post (Item typ vt ref) <$ checkEq (getPosEntry entry) typ typ')
 
   -- TODO other error for unimplemented
-  _ -> throw (getPosn e,"Type mismatch. Expression " <> show e <> " does not have type " <> show typ)
+  _ -> throw (getPosn e,"Type mismatch. Expression does not have type " <> show typ)
 
   where
     polycheck :: Pn -> (forall y. Pn -> SType y -> Exp y t -> Exp y t -> Exp x t) -> U.Expr -> U.Expr -> Err (Exp x t)

--- a/tests/frontend/fail/cycle.act
+++ b/tests/frontend/fail/cycle.act
@@ -1,0 +1,32 @@
+constructor of A
+interface constructor()
+
+creates
+   uint x := 0
+   B b := B()
+
+constructor of B
+interface constructor()
+
+creates
+   uint y := 0
+   A a := A()
+
+behaviour remote of B
+interface set_remote(uint z)
+
+iff
+   CALLVALUE == 0
+
+storage
+   a.x => z
+
+behaviour multi of B
+interface set_remote2(uint z)
+
+iff
+   CALLVALUE == 0
+
+storage
+   y => 1
+   a.x => z

--- a/tests/frontend/fail/cycle2.act
+++ b/tests/frontend/fail/cycle2.act
@@ -1,0 +1,45 @@
+//  Call graph:
+//
+//      C
+//     / \
+//    A   B
+//         \
+//          D
+//           \
+//            C
+
+constructor of A
+interface constructor()
+
+creates
+   uint x := 0
+
+constructor of B
+interface constructor(uint x)
+
+creates
+   uint y := x
+   D d := D()
+
+behaviour remote of B
+interface set_remote(uint z)
+
+iff
+   CALLVALUE == 0
+
+storage
+   d.x => z
+
+constructor of C
+interface constructor(uint u)
+
+creates
+   B b := B(u)
+
+
+constructor of D
+interface constructor()
+
+creates
+   C c := C(0)
+   uint x := 0

--- a/tests/frontend/fail/cycle2.act
+++ b/tests/frontend/fail/cycle2.act
@@ -35,7 +35,7 @@ interface constructor(uint u)
 
 creates
    B b := B(u)
-
+   A a := A()
 
 constructor of D
 interface constructor()


### PR DESCRIPTION
Implements a depth first search in the constructor call graph to find circular dependencies, and throws an error if one is found. 