### PR TITLE
Fix bug related to missing constraints from case conditions.

### DIFF
--- a/src/SMT.hs
+++ b/src/SMT.hs
@@ -176,7 +176,7 @@ mkPostconditionQueries (Act _ contr) = concatMap mkPostconditionQueriesContract 
       mkPostconditionQueriesConstr constr <> concatMap mkPostconditionQueriesBehv behvs
 
 mkPostconditionQueriesBehv :: Behaviour -> [Query]
-mkPostconditionQueriesBehv behv@(Behaviour _ _ (Interface ifaceName decls) preconds ifs postconds stateUpdates _) = mkQuery <$> postconds
+mkPostconditionQueriesBehv behv@(Behaviour _ _ (Interface ifaceName decls) preconds caseconds postconds stateUpdates _) = mkQuery <$> postconds
   where
     -- declare vars
     storage = concatMap (declareStorageLocation . locFromRewrite) stateUpdates
@@ -184,7 +184,7 @@ mkPostconditionQueriesBehv behv@(Behaviour _ _ (Interface ifaceName decls) preco
     envs = declareEthEnv <$> ethEnvFromBehaviour behv
 
     -- constraints
-    pres = mkAssert ifaceName <$> preconds <> ifs
+    pres = mkAssert ifaceName <$> preconds <> caseconds
     updates = encodeUpdate ifaceName <$> stateUpdates
 
     mksmt e = SMTExp
@@ -284,7 +284,7 @@ mkInvariantQueries (Act _ contracts) = fmap mkQuery gathered
         -- constraints
         preInv = mkAssert ctorIface $ invPre
         postInv = mkAssert ctorIface . Neg nowhere $ invPost
-        behvConds = mkAssert behvIface <$> _preconditions behv
+        behvConds = mkAssert behvIface <$> _preconditions behv <> _caseconditions behv
         invConds' = mkAssert ctorIface <$> invConds <> invStorageBounds
         implicitLocs' = encodeUpdate ctorIface <$> implicitLocs
         updates = encodeUpdate behvIface <$> _stateUpdates behv

--- a/tests/invariants/pass/case.act
+++ b/tests/invariants/pass/case.act
@@ -1,0 +1,24 @@
+constructor of C
+interface constructor()
+
+creates
+   uint x := 0
+
+invariants
+  x == 0
+	
+behaviour bar of C
+interface bar(uint z)
+
+iff
+   CALLVALUE == 0
+
+case z == 0:
+
+storage
+  x => z
+
+case true:
+
+storage
+  x => 0


### PR DESCRIPTION
This adds case conditions to the invariant constraints so that they are taken into account when checking invariants. This was a bug introduced by #145, that split preconditions into preconditions (i.e., ensures) and case conditions. 

It also adds a test that checks whether the case conditions are taken into account when proving invariants. 