### PR TITLE
TimeAgnostic to exposed modules

### DIFF
--- a/src/act.cabal
+++ b/src/act.cabal
@@ -45,8 +45,8 @@ library
   build-tool-depends: happy:happy, alex:alex
   hs-source-dirs:     .
   default-language:   Haskell2010
-  exposed-modules:    CLI Error Print SMT Syntax.Annotated
-  other-modules:      Lex Parse K Coq Syntax Syntax.Untyped Syntax.Typed Syntax.Types Syntax.Timing Syntax.TimeAgnostic Type Enrich Dev
+  exposed-modules:    CLI Error Print SMT Syntax.Annotated Syntax.TimeAgnostic
+  other-modules:      Lex Parse K Coq Syntax Syntax.Untyped Syntax.Typed Syntax.Types Syntax.Timing Type Enrich Dev
 
 executable act
   import:             deps


### PR DESCRIPTION
For open games I've needed to expose the time-agnostic AST. Can we add it to the list of exported modules?