### PR TITLE
doc: add latex support

### DIFF
--- a/doc/book.toml
+++ b/doc/book.toml
@@ -1,5 +1,5 @@
 [book]
-authors = ["David Terry"]
+authors = ["dxo"]
 language = "en"
 multilingual = false
 src = "src"
@@ -8,6 +8,8 @@ title = "The Act Book"
 [preprocessor]
 [preprocessor.mermaid]
 command = "mdbook-mermaid"
+[preprocessor.katex]
+after = ["links"]
 
 [output]
 [output.html]

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
             pkgs.solc
             pkgs.mdbook
             pkgs.mdbook-mermaid
+            pkgs.mdbook-katex
           ];
           withHoogle = true;
           shellHook = ''


### PR DESCRIPTION
Adds latex support to the documentation using: https://github.com/lzanini/mdbook-katex