### PR TITLE
Equivalence with HEVM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@6ed004b9ccb68dbc28e7c85bee15fa93dbd214ac # v22
+      - uses: cachix/install-nix-action@v22
         with:
           skip_adding_nixpkgs_channel: false
-      - uses: cachix/cachix-action@6a9a34cdd93d0ae4b4b59fd678660efb08109f2f # v12
+      - uses: cachix/cachix-action@v12
         with:
           name: dapp
           skipPush: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@29bd9290ef037a3ecbdafe83cbd2185e9dd0fa0a # v20
+      - uses: cachix/install-nix-action@6ed004b9ccb68dbc28e7c85bee15fa93dbd214ac # v20
         with:
           skip_adding_nixpkgs_channel: false
       - uses: cachix/cachix-action@6a9a34cdd93d0ae4b4b59fd678660efb08109f2f # v12

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@6ed004b9ccb68dbc28e7c85bee15fa93dbd214ac # v20
+      - uses: cachix/install-nix-action@6ed004b9ccb68dbc28e7c85bee15fa93dbd214ac # v22
         with:
           skip_adding_nixpkgs_channel: false
       - uses: cachix/cachix-action@6a9a34cdd93d0ae4b4b59fd678660efb08109f2f # v12

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v20
+      - uses: cachix/install-nix-action@v22
       - uses: cachix/cachix-action@v12
         with:
           name: dapp

--- a/Makefile
+++ b/Makefile
@@ -89,19 +89,19 @@ tests/%.type.fail:
 
 tests/%.invariant.pass:
 	./bin/act prove --file tests/$*
-	./bin/act prove --solver cvc4 --file tests/$*
+	./bin/act prove --solver cvc5 --file tests/$*
 
 tests/%.invariant.fail:
 	./bin/act prove --file tests/$* && exit 1 || echo 0
-	./bin/act prove --solver cvc4 --file tests/$* && exit 1 || echo 0
+	./bin/act prove --solver cvc5 --file tests/$* && exit 1 || echo 0
 
 tests/%.postcondition.pass:
 	./bin/act prove --file tests/$*
-	./bin/act prove --solver cvc4 --file tests/$*
+	./bin/act prove --solver cvc5 --file tests/$*
 
 tests/%.postcondition.fail:
 	./bin/act prove --file tests/$* && exit 1 || echo 0
-	./bin/act prove --solver cvc4 --file tests/$* && exit 1 || echo 0
+	./bin/act prove --solver cvc5 --file tests/$* && exit 1 || echo 0
 
 # tests/hevm/pass/%.act.hevm.pass:
 # 	solc --combined-json=bin,bin-runtime,ast,metadata,abi,srcmap,srcmap-runtime,storage-layout tests/hevm/pass/$*.sol > tests/hevm/pass/$*.sol.json

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -8,3 +8,4 @@
   - [Coq](./coq.md)
   - [Hevm](./hevm.md)
 - [Internals](./internals.md)
+- [HEVM Equivalence](./equiv.md)

--- a/doc/src/equiv.md
+++ b/doc/src/equiv.md
@@ -1,0 +1,50 @@
+# Checking equivalence with EVM bytecode
+
+EVM bytecode can be formally verified to implement an Act spec. This
+means that each successful behavior of the bytecode should be covered
+by the Act spect. To check equivalence the Act spec is translated to
+Expr, the intermediate representation of HEVM, and the EVM bytecode is
+symbolically executed to obtain its Expr representation. Then
+equivalence can be checked with the equivalence checker of HEVM.
+
+The Expr representation of an Act program is a list of *Success*
+nodes, that contain the possible successful results of the
+computation. The Expr representation of the EVM bytecode can also be
+flattened to a list of result nodes from which we only keep the
+successful executions, filtering out failed and partial execution
+paths and
+
+A success node in Expr, `Success cond res storage`, is a leaf in the
+Expr tree representation and contains the path conditions, `cond` that
+lead to the leaf, the result buffer `buf`, and the end state
+`storage`.
+
+
+## Equivalence checks 
+To check equivalence between the two Expr representations the
+following checks are performed. 
+
+### Result equivalence
+The two list of `Success` node are being checked for equivalence using
+the HEVM equivalence checker. For each pair of nodes in the two lists,
+we check that of all inputs that satisfy the path conditions the
+result and final storage the same. 
+
+### Input space equivalence
+Since the input space of the two list is not necessarily exhaustive,
+since some input may lead to failed execution paths that are not
+present in the list, we need to check that the input space of the two
+lists are the same. That is, there must not be inputs that satisfy
+some path condition in the first list but not the second and vice verse. 
+
+Say that the Act program has the Expr representation 
+`[Success c1 r1 s1, ..., Success cn rn sn`
+and the the EVM bytecode has the Expr representation 
+`[Success c1' r1' s1', ..., Success cn' rn' sn'`
+
+then we need to check that `c1 \/ .. \/ cn <-> c1' \/ .. \/ cn'` that
+is, we require that `c1 \/ .. \/ cn /\ ~ (c1' \/ .. \/ cn')` and `c1'
+\/ .. \/ cn' /\ ~ (c1 \/ .. \/ cn)` are both unsatisfiable.
+
+### Exhaustiveness checks for bytecode
+TODO

--- a/doc/src/equiv.md
+++ b/doc/src/equiv.md
@@ -12,7 +12,8 @@ nodes, that contain the possible successful results of the
 computation. The Expr representation of the EVM bytecode can also be
 flattened to a list of result nodes from which we only keep the
 successful executions, filtering out failed and partial execution
-paths.
+paths. An informative warning will be thrown when partial executions
+are encountered.
 
 A success node in Expr, `Success cond res storage`, is a leaf in the
 Expr tree representation and contains the path conditions, `cond` that

--- a/doc/src/language.md
+++ b/doc/src/language.md
@@ -213,11 +213,12 @@ ensures
 
 ## Multiple contracts
 
-Act supports defining multiple contracts in the same file. State variables can have
-contracts types and they can be initiallized by calling the corresponding constructor. 
-The state variables of some contract can be accessed using dot notation `.`.
+Act supports defining multiple contracts in the same file. State
+variables can have contracts types and they can be initialized by
+calling the corresponding constructor.  The state variables of some
+contract can be accessed using dot notation `.`.
 
-Example: 
+Example:
 
 ```
 constructor of A
@@ -240,4 +241,40 @@ iff
 
 storage
    a.x => z
+```
+
+
+## Range predicates
+Often, to accurately specify a contract, we need to assume that
+arithmetic operations do not overflow. This is done with built-in
+*in-range* predicates. For example, in the iff conditions of a
+constructor of behaviour we can write
+
+
+```
+iff
+   inRange(uint256, (a + b) - c)
+   CALLVALUE =/= 0
+```
+
+meaning that all subexpressions of `(a + b) - c` will always be in the
+range of a 256-bit integer and no overflow or underflow occurs.
+
+Such in range predicates can be conditional, for example
+
+```
+CALLER =/= x => inRange(uint256, (a + b) - c)
+```
+
+
+To conveniently pack many in range predicates together Act provides an
+alternative form of iff conditions
+
+```
+iff
+   CALLVALUE =/= 0
+
+iff in range uint256
+   (a + b) - c
+   d - e
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "ethereum-tests": {
       "flake": false,
       "locked": {
-        "lastModified": 1668955227,
-        "narHash": "sha256-t9GV1TUfXr6xwgRvCaf43oGhBLdlYJwNCmaR4rIYV1M=",
+        "lastModified": 1682506704,
+        "narHash": "sha256-PyFZhdUQRUbmohoMS+w41rmSFfKeTO2RqHLetWlU4Jw=",
         "owner": "ethereum",
         "repo": "tests",
-        "rev": "a16217cff68fa587a4a8b8b008e5cf374a6086b5",
+        "rev": "b25623d4d7df10e38498cace7adc7eb413c4b20d",
         "type": "github"
       },
       "original": {
         "owner": "ethereum",
-        "ref": "v11.2",
+        "ref": "v12.2",
         "repo": "tests",
         "type": "github"
       }
@@ -114,17 +114,17 @@
         "solidity": "solidity"
       },
       "locked": {
-        "lastModified": 1685024205,
-        "narHash": "sha256-0ooQxVWgVFAWy1sLSD9JOLhaihwNEVlVw4KU50leHbc=",
+        "lastModified": 1685708415,
+        "narHash": "sha256-kdMiRVzMXmmU9rG5tg776w3V0FXQlhtKEKX0V6Yslqs=",
         "owner": "ethereum",
         "repo": "hevm",
-        "rev": "6aa10d18f03ef7b65dad6b86e9b99ff1bb305c16",
+        "rev": "87a171da0437ac4902a723b78352a3e509c7dcc9",
         "type": "github"
       },
       "original": {
         "owner": "ethereum",
         "repo": "hevm",
-        "rev": "6aa10d18f03ef7b65dad6b86e9b99ff1bb305c16",
+        "rev": "87a171da0437ac4902a723b78352a3e509c7dcc9",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -114,17 +114,17 @@
         "solidity": "solidity"
       },
       "locked": {
-        "lastModified": 1686917643,
-        "narHash": "sha256-sSdVklkaQZGdQFpt8d+0XcTaUKMg+VKmBCxmrwcm+Y4=",
+        "lastModified": 1687852312,
+        "narHash": "sha256-+M/ge7lNbWmBWjaqoQaDeuIsp7mhqteNKBXkap9LlAc=",
         "owner": "ethereum",
         "repo": "hevm",
-        "rev": "cd3440a26a7445f8acce84109db2179748c679aa",
+        "rev": "e51f0bbdc6043aa2fb20cb69194215cdc62b5d75",
         "type": "github"
       },
       "original": {
         "owner": "ethereum",
         "repo": "hevm",
-        "rev": "cd3440a26a7445f8acce84109db2179748c679aa",
+        "rev": "e51f0bbdc6043aa2fb20cb69194215cdc62b5d75",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -114,17 +114,17 @@
         "solidity": "solidity"
       },
       "locked": {
-        "lastModified": 1686653021,
-        "narHash": "sha256-oCe2WqW1mdP+UZnzDzDDrk8Ab7NGH7HjXdALsNr4ueE=",
+        "lastModified": 1686917643,
+        "narHash": "sha256-sSdVklkaQZGdQFpt8d+0XcTaUKMg+VKmBCxmrwcm+Y4=",
         "owner": "ethereum",
         "repo": "hevm",
-        "rev": "81f75a2ca34f5bb3202d207c3c07ca1740842717",
+        "rev": "cd3440a26a7445f8acce84109db2179748c679aa",
         "type": "github"
       },
       "original": {
         "owner": "ethereum",
         "repo": "hevm",
-        "rev": "81f75a2ca34f5bb3202d207c3c07ca1740842717",
+        "rev": "cd3440a26a7445f8acce84109db2179748c679aa",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,38 @@
 {
   "nodes": {
+    "ethereum-tests": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668955227,
+        "narHash": "sha256-t9GV1TUfXr6xwgRvCaf43oGhBLdlYJwNCmaR4rIYV1M=",
+        "owner": "ethereum",
+        "repo": "tests",
+        "rev": "a16217cff68fa587a4a8b8b008e5cf374a6086b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ethereum",
+        "ref": "v11.2",
+        "repo": "tests",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -18,7 +51,114 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "foundry": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1677921223,
+        "narHash": "sha256-TsrPW+VfLu19dYm4uuAaM9LLHm30iZiyW1+0mbFgwbk=",
+        "owner": "shazow",
+        "repo": "foundry.nix",
+        "rev": "79df1481c10789570c40749a4c8f8aada16f2eea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shazow",
+        "ref": "monthly",
+        "repo": "foundry.nix",
+        "type": "github"
+      }
+    },
+    "hevmUpstream": {
+      "inputs": {
+        "ethereum-tests": "ethereum-tests",
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils_2",
+        "foundry": "foundry",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-solc": "nixpkgs-solc",
+        "solidity": "solidity"
+      },
+      "locked": {
+        "lastModified": 1685024205,
+        "narHash": "sha256-0ooQxVWgVFAWy1sLSD9JOLhaihwNEVlVw4KU50leHbc=",
+        "owner": "ethereum",
+        "repo": "hevm",
+        "rev": "6aa10d18f03ef7b65dad6b86e9b99ff1bb305c16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ethereum",
+        "repo": "hevm",
+        "rev": "6aa10d18f03ef7b65dad6b86e9b99ff1bb305c16",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1666753130,
+        "narHash": "sha256-Wff1dGPFSneXJLI2c0kkdWTgxnQ416KE6X4KnFkgPYQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f540aeda6f677354f1e7144ab04352f61aaa0118",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-solc": {
+      "locked": {
+        "lastModified": 1672059513,
+        "narHash": "sha256-4R7lESB3biVNyE6rXkjw3mhowzg4zTQgZElM4/dRUv8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1b71def42b74811323de2df52f180b795ec506fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1b71def42b74811323de2df52f180b795ec506fc",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1684164265,
         "narHash": "sha256-ZqNSKSQM12040taiRvSgqwUCPlN1qZAw6nYniYuY1hs=",
@@ -36,7 +176,25 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "hevmUpstream": "hevmUpstream",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "solidity": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1670421565,
+        "narHash": "sha256-VCZDKQHnMsXu+ucsT5BLPYQoZ2FYjpyGbDVoDYjr1W8=",
+        "owner": "ethereum",
+        "repo": "solidity",
+        "rev": "1c8745c54a239d20b6fb0f79a8bd2628d779b27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ethereum",
+        "repo": "solidity",
+        "rev": "1c8745c54a239d20b6fb0f79a8bd2628d779b27e",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.lock
+++ b/flake.lock
@@ -114,17 +114,17 @@
         "solidity": "solidity"
       },
       "locked": {
-        "lastModified": 1685708415,
-        "narHash": "sha256-kdMiRVzMXmmU9rG5tg776w3V0FXQlhtKEKX0V6Yslqs=",
+        "lastModified": 1686653021,
+        "narHash": "sha256-oCe2WqW1mdP+UZnzDzDDrk8Ab7NGH7HjXdALsNr4ueE=",
         "owner": "ethereum",
         "repo": "hevm",
-        "rev": "87a171da0437ac4902a723b78352a3e509c7dcc9",
+        "rev": "81f75a2ca34f5bb3202d207c3c07ca1740842717",
         "type": "github"
       },
       "original": {
         "owner": "ethereum",
         "repo": "hevm",
-        "rev": "87a171da0437ac4902a723b78352a3e509c7dcc9",
+        "rev": "81f75a2ca34f5bb3202d207c3c07ca1740842717",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -114,17 +114,17 @@
         "solidity": "solidity"
       },
       "locked": {
-        "lastModified": 1687852312,
-        "narHash": "sha256-+M/ge7lNbWmBWjaqoQaDeuIsp7mhqteNKBXkap9LlAc=",
+        "lastModified": 1687798734,
+        "narHash": "sha256-ONgHhKUtRhyBUIPclsDl3WPebSEVFCgYRda2pBjjiIs=",
         "owner": "ethereum",
         "repo": "hevm",
-        "rev": "e51f0bbdc6043aa2fb20cb69194215cdc62b5d75",
+        "rev": "dbe984a96042a3873ecdffb84c60151d6229689a",
         "type": "github"
       },
       "original": {
         "owner": "ethereum",
         "repo": "hevm",
-        "rev": "e51f0bbdc6043aa2fb20cb69194215cdc62b5d75",
+        "rev": "dbe984a96042a3873ecdffb84c60151d6229689a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs";
     hevmUpstream = {
-      url = "github:ethereum/hevm/81f75a2ca34f5bb3202d207c3c07ca1740842717";
+      url = "github:ethereum/hevm/cd3440a26a7445f8acce84109db2179748c679aa";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -22,7 +22,7 @@
 	};
         act = (myHaskellPackages.callCabal2nixWithOptions "act" (gitignore ./src) "-fci" {})
           .overrideAttrs (attrs : {
-            buildInputs = attrs.buildInputs ++ [ pkgs.z3 pkgs.cvc4 ];
+            buildInputs = attrs.buildInputs ++ [ pkgs.z3 pkgs.cvc4 pkgs.cvc5 ];
           });
       in rec {
         packages.act = act;
@@ -41,6 +41,7 @@
             pkgs.jq
             pkgs.z3
             pkgs.cvc4
+            pkgs.cvc5
             pkgs.coq
             pkgs.solc
             pkgs.mdbook
@@ -50,6 +51,7 @@
           withHoogle = true;
           shellHook = ''
             export PATH=$(pwd)/bin:$PATH
+	    export DYLD_LIBRARY_PATH="${libraryPath}"
           '';
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs";
     hevmUpstream = {
-      url = "github:ethereum/hevm/dbe984a96042a3873ecdffb84c60151d6229689a";
+      url = "github:ethereum/hevm";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
 	};
         act = (myHaskellPackages.callCabal2nixWithOptions "act" (gitignore ./src) "-fci" {})
           .overrideAttrs (attrs : {
-            buildInputs = attrs.buildInputs ++ [ pkgs.z3 pkgs.cvc4 pkgs.cvc5 ];
+            buildInputs = attrs.buildInputs ++ [ pkgs.z3 pkgs.cvc5 ];
           });
       in rec {
         packages.act = act;
@@ -40,7 +40,6 @@
             haskell-language-server
             pkgs.jq
             pkgs.z3
-            pkgs.cvc4
             pkgs.cvc5
             pkgs.coq
             pkgs.solc

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs";
     hevmUpstream = {
-      url = "github:ethereum/hevm/87a171da0437ac4902a723b78352a3e509c7dcc9";
+      url = "github:ethereum/hevm/81f75a2ca34f5bb3202d207c3c07ca1740842717";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -31,7 +31,9 @@
         apps.act = flake-utils.lib.mkApp { drv = packages.act; };
         apps.default = apps.act;
 
-        devShell = myHaskellPackages.shellFor {
+        devShell = with pkgs;
+          let libraryPath = "${lib.makeLibraryPath [ libff secp256k1 gmp ]}";
+          in myHaskellPackages.shellFor {
           packages = _: [ act ];
           buildInputs = with pkgs.haskellPackages; [
             cabal-install

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs";
     hevmUpstream = {
-      url = "github:ethereum/hevm/6aa10d18f03ef7b65dad6b86e9b99ff1bb305c16";
+      url = "github:ethereum/hevm/87a171da0437ac4902a723b78352a3e509c7dcc9";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs";
     hevmUpstream = {
-      url = "github:ethereum/hevm/e51f0bbdc6043aa2fb20cb69194215cdc62b5d75";
+      url = "github:ethereum/hevm/dbe984a96042a3873ecdffb84c60151d6229689a";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs";
     hevmUpstream = {
-      url = "github:ethereum/hevm/cd3440a26a7445f8acce84109db2179748c679aa";
+      url = "github:ethereum/hevm/e51f0bbdc6043aa2fb20cb69194215cdc62b5d75";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -50,8 +50,8 @@ import EVM.SymExec
 import qualified EVM.Solvers as Solvers
 import EVM.Solidity
 import qualified EVM.Format as Format
-import qualified EVM.Types as Expr
-import qualified EVM.Expr as Expr
+import qualified EVM.Types as EVM
+import qualified EVM.Expr as EVM
 import qualified EVM.Fetch as Fetch
 
 --command line options
@@ -238,9 +238,9 @@ hevm actspec cid sol' solver' timeout _ = do
     getBranches solvers bs calldata = do
       let
         bytecode = if BS.null bs then BS.pack [0] else bs
-        prestate = abstractVM calldata bytecode Nothing Expr.AbstractStore
+        prestate = abstractVM calldata bytecode Nothing EVM.AbstractStore
       expr <- interpret (Fetch.oracle solvers Nothing) Nothing 1 StackBased prestate runExpr
-      let simpl = if True then (Expr.simplify expr) else expr
+      let simpl = if True then (EVM.simplify expr) else expr
       let nodes = flattenExpr simpl
 
       when (any isPartial nodes) $ do
@@ -253,7 +253,7 @@ hevm actspec cid sol' solver' timeout _ = do
 
     removeFails branches = filter isSuccess $ branches
 
-    isSuccess (Expr.Success _ _ _) = True
+    isSuccess (EVM.Success _ _ _) = True
     isSuccess _ = False
     
     checkResult :: [EquivResult] -> IO ()
@@ -269,7 +269,7 @@ hevm actspec cid sol' solver' timeout _ = do
           TIO.putStrLn . Text.unlines $
             [ "Not equivalent. The following inputs result in differing behaviours:"
             , "" , "-----", ""
-            ] <> (intersperse (Text.unlines [ "", "-----" ]) $ fmap (formatCex (Expr.AbstractBuf "txdata")) cexs)
+            ] <> (intersperse (Text.unlines [ "", "-----" ]) $ fmap (formatCex (EVM.AbstractBuf "txdata")) cexs)
           exitFailure
 
 

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -46,8 +46,6 @@ import Type
 import Coq hiding (indent)
 import HEVM
 
-import Debug.Trace
-
 import EVM.SymExec
 import qualified EVM.Solvers as Solvers
 import EVM.Solidity
@@ -260,7 +258,6 @@ hevm actspec cid sol' solver' timeout _ = do
     
     checkResult :: [EquivResult] -> IO ()
     checkResult res =
-      traceShow res $
       case any isCex res of
         False -> do
           putStrLn "No discrepancies found"

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -227,13 +227,16 @@ hevm actspec cid sol = do
   sequence_ $ flip fmap actbehvs $ \(behvs,calldata) ->
     Solvers.withSolvers Solvers.Z3 1 Nothing $ \solvers -> do
       solbehvs <- removeFails <$> getBranches solvers bytecode calldata
+      traceM "Calldata"
+      traceShowM (fst calldata)
+      traceShowM (snd calldata)
       traceM "Solidity"
       traceShowM solbehvs
       traceM "ACT"
       traceShowM behvs
       -- equivalence check
       putStrLn "Checking if behaviours are equivalent"
-      checkResult =<< equivalenceCheck' solvers solbehvs behvs defaultVeriOpts
+      checkResult =<< equivalenceCheck' solvers solbehvs behvs debugVeriOpts
       -- exhaustiveness sheck
       putStrLn "Checking if the input space is the same"
       checkResult =<< checkInputSpaces solvers debugVeriOpts solbehvs behvs
@@ -254,7 +257,7 @@ hevm actspec cid sol = do
 
     checkResult :: [EquivResult] -> IO ()
     checkResult res =
-      traceShow res $ 
+      traceShow res $
       case any isCex res of
         False -> do
           putStrLn "No discrepancies found"

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -236,7 +236,7 @@ hevm actspec cid sol = do
       checkResult =<< equivalenceCheck' solvers solbehvs behvs defaultVeriOpts
       -- exhaustiveness sheck
       putStrLn "Checking if the input space is the same"
-      checkResult =<< checkInputSpaces solvers solbehvs behvs
+      checkResult =<< checkInputSpaces solvers debugVeriOpts solbehvs behvs
   where
     -- decompiles the given bytecode into a list of branches
     getBranches solvers bs calldata = do

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -253,7 +253,7 @@ hevm actspec cid sol' solver' timeout _ = do
 
     removeFails branches = filter isSuccess $ branches
 
-    isSuccess (EVM.Success _ _ _) = True
+    isSuccess (EVM.Success _ _ _ _) = True
     isSuccess _ = False
     
     checkResult :: [EquivResult] -> IO ()

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -132,11 +132,6 @@ type' f = do
   contents <- readFile f
   validation (prettyErrs contents) (B.putStrLn . encode) (enrich <$> compile contents)
 
--- type'' :: FilePath -> IO Act
--- type'' f = do
---   contents <- readFile f
---   validation (\_ -> pure $ Act Map.empty []) pure (enrich <$> compile contents)
-
 parseSolver :: Maybe Text -> Solvers.Solver
 parseSolver s = case s of
                   Nothing -> Solvers.Z3

--- a/src/Coq.hs
+++ b/src/Coq.hs
@@ -347,7 +347,8 @@ coqprop (LT _ e1 e2)   = parens $ coqexp e1 <> " < "  <> coqexp e2
 coqprop (LEQ _ e1 e2)  = parens $ coqexp e1 <> " <= " <> coqexp e2
 coqprop (GT _ e1 e2)   = parens $ coqexp e1 <> " > "  <> coqexp e2
 coqprop (GEQ _ e1 e2)  = parens $ coqexp e1 <> " >= " <> coqexp e2
-coqprop _ = error "ill formed proposition"
+coqprop (InRange _ t e) = coqprop (bound t e)
+coqprop e = error "ill formed proposition: " <> T.pack (show e)
 
 -- | coq syntax for a typed expression
 typedexp :: TypedExp -> T.Text

--- a/src/Coq.hs
+++ b/src/Coq.hs
@@ -320,7 +320,7 @@ coqexp (ITE _ b e1 e2) = parens $ "if "
 coqexp (IntEnv _ envVal) = parens $ T.pack (show envVal) <> " " <> envVar
 -- Contracts
 coqexp (Var _ SContract name) = T.pack name
-coqexp (Create _ _ cid args) = parens $ T.pack cid <> "." <> T.pack cid <> " " <> envVar <> " " <> coqargs args
+coqexp (Create _ cid args) = parens $ T.pack cid <> "." <> T.pack cid <> " " <> envVar <> " " <> coqargs args
 -- unsupported
 coqexp Cat {} = error "bytestrings not supported"
 coqexp Slice {} = error "bytestrings not supported"

--- a/src/Coq.hs
+++ b/src/Coq.hs
@@ -12,6 +12,8 @@
 {-# Language OverloadedStrings #-}
 {-# Language RecordWildCards #-}
 {-# LANGUAGE GADTs #-}
+{-# Language DataKinds #-}
+
 
 module Coq where
 
@@ -304,6 +306,8 @@ coqexp (IntMin _ n)  = parens $ "INT_MIN "  <> T.pack (show n)
 coqexp (IntMax _ n)  = parens $ "INT_MAX "  <> T.pack (show n)
 coqexp (UIntMin _ n) = parens $ "UINT_MIN " <> T.pack (show n)
 coqexp (UIntMax _ n) = parens $ "UINT_MAX " <> T.pack (show n)
+
+coqexp (InRange _ t e) = coqexp (bound t e)
 
 -- polymorphic
 coqexp (TEntry _ w e) = entry e w

--- a/src/HEVM.hs
+++ b/src/HEVM.hs
@@ -11,7 +11,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Expr where
+module HEVM where
 
 import qualified Data.Map as M
 import Data.List

--- a/src/HEVM.hs
+++ b/src/HEVM.hs
@@ -316,7 +316,7 @@ checkInputSpaces solvers _ l1 l2 = do
 
   when True $ forM_ (zip [(1 :: Int)..] queries) $ \(idx, q) -> do
     TL.writeFile
-      ("query-" <> show idx <> ".smt2")
+      ("input-query-" <> show idx <> ".smt2")
       (formatSMT2 q <> "\n\n(check-sat)")
 
   results <- fmap toVRes <$> mapConcurrently (checkSat solvers) queries

--- a/src/HEVM.hs
+++ b/src/HEVM.hs
@@ -195,7 +195,7 @@ ethEnvToWord Callvalue = EVM.CallValue 0
 ethEnvToWord Caller = EVM.Caller 0
 ethEnvToWord Origin = EVM.Origin
 ethEnvToWord Blocknumber = EVM.BlockNumber
-ethEnvToWord Blockhash = EVM.BlockHash 0
+ethEnvToWord Blockhash = error "TODO" -- EVM.BlockHash ??
 ethEnvToWord Chainid = EVM.ChainId
 ethEnvToWord Gaslimit = EVM.GasLimit
 ethEnvToWord Coinbase = EVM.Coinbase
@@ -209,112 +209,112 @@ ethEnvToBuf :: EthEnv -> EVM.Expr EVM.Buf
 ethEnvToBuf _ = error "Internal error: there are no bytestring environment values"
 
 
-toProp :: Layout -> Exp ABoolean -> Types.Prop
+toProp :: Layout -> Exp ABoolean -> EVM.Prop
 toProp layout = \case
-  (And _ e1 e2) -> pop2 Types.PAnd e1 e2
-  (Or _ e1 e2) -> pop2 Types.POr e1 e2
-  (Impl _ e1 e2) -> pop2 Types.PImpl e1 e2
-  (Neg _ e1) -> Types.PNeg (toProp layout e1)
-  (Syntax.Annotated.LT _ e1 e2) -> op2 Types.PLT e1 e2
-  (LEQ _ e1 e2) -> op2 Types.PLEq e1 e2
-  (GEQ _ e1 e2) -> op2 Types.PGEq e1 e2
-  (Syntax.Annotated.GT _ e1 e2) -> op2 Types.PGT e1 e2
-  (LitBool _ b) -> Types.PBool b
-  (Eq _ SInteger e1 e2) -> op2 Types.PEq e1 e2
-  (Eq _ SBoolean e1 e2) -> op2 Types.PEq e1 e2
+  (And _ e1 e2) -> pop2 EVM.PAnd e1 e2
+  (Or _ e1 e2) -> pop2 EVM.POr e1 e2
+  (Impl _ e1 e2) -> pop2 EVM.PImpl e1 e2
+  (Neg _ e1) -> EVM.PNeg (toProp layout e1)
+  (Syntax.Annotated.LT _ e1 e2) -> op2 EVM.PLT e1 e2
+  (LEQ _ e1 e2) -> op2 EVM.PLEq e1 e2
+  (GEQ _ e1 e2) -> op2 EVM.PGEq e1 e2
+  (Syntax.Annotated.GT _ e1 e2) -> op2 EVM.PGT e1 e2
+  (LitBool _ b) -> EVM.PBool b
+  (Eq _ SInteger e1 e2) -> op2 EVM.PEq e1 e2
+  (Eq _ SBoolean e1 e2) -> op2 EVM.PEq e1 e2
   (Eq _ _ _ _) -> error "unsupported"
-  (NEq _ SInteger e1 e2) -> Types.PNeg $ op2 Types.PEq e1 e2
-  (NEq _ SBoolean e1 e2) -> Types.PNeg $ op2 Types.PEq e1 e2
+  (NEq _ SInteger e1 e2) -> EVM.PNeg $ op2 EVM.PEq e1 e2
+  (NEq _ SBoolean e1 e2) -> EVM.PNeg $ op2 EVM.PEq e1 e2
   (NEq _ _ _ _) -> error "unsupported"
   (ITE _ _ _ _) -> error "Internal error: expecting flat expression"
-  (Var _ _ _) -> error "TODO" -- (Types.Var (T.pack x)) -- vars can only be words? TODO other types
-  (TEntry _ _ _) -> error "TODO" -- Types.SLoad addr idx
+  (Var _ _ _) -> error "TODO" -- (EVM.Var (T.pack x)) -- vars can only be words? TODO other types
+  (TEntry _ _ _) -> error "TODO" -- EVM.SLoad addr idx
   (InRange _ t e) -> toProp layout (inRange t e)
   where
-    op2 :: forall a b. (Types.Expr (ExprType b) -> Types.Expr (ExprType b) -> a) -> Exp b -> Exp b -> a
+    op2 :: forall a b. (EVM.Expr (ExprType b) -> EVM.Expr (ExprType b) -> a) -> Exp b -> Exp b -> a
     op2 op e1 e2 = op (toExpr layout e1) (toExpr layout e2)
 
-    pop2 :: forall a. (Types.Prop -> Types.Prop -> a) -> Exp ABoolean -> Exp ABoolean -> a
+    pop2 :: forall a. (EVM.Prop -> EVM.Prop -> a) -> Exp ABoolean -> Exp ABoolean -> a
     pop2 op e1 e2 = op (toProp layout e1) (toProp layout e2)
 
 
 
-toExpr :: forall a. Layout -> Exp a -> Types.Expr (ExprType a)
+toExpr :: forall a. Layout -> Exp a -> EVM.Expr (ExprType a)
 toExpr layout = \case
   -- booleans
-  (And _ e1 e2) -> op2 Types.And e1 e2
-  (Or _ e1 e2) -> op2 Types.Or e1 e2
-  (Impl _ e1 e2) -> op2 (\x y -> Types.Or (Types.Not x) y) e1 e2
-  (Neg _ e1) -> Types.Not (toExpr layout e1)
-  (Syntax.Annotated.LT _ e1 e2) -> op2 Types.LT e1 e2
-  (LEQ _ e1 e2) -> op2 Types.LEq e1 e2
-  (GEQ _ e1 e2) -> op2 Types.GEq e1 e2
-  (Syntax.Annotated.GT _ e1 e2) -> op2 Types.GT e1 e2
-  (LitBool _ b) -> Types.Lit (fromIntegral $ fromEnum $ b)
+  (And _ e1 e2) -> op2 EVM.And e1 e2
+  (Or _ e1 e2) -> op2 EVM.Or e1 e2
+  (Impl _ e1 e2) -> op2 (\x y -> EVM.Or (EVM.Not x) y) e1 e2
+  (Neg _ e1) -> EVM.Not (toExpr layout e1)
+  (Syntax.Annotated.LT _ e1 e2) -> op2 EVM.LT e1 e2
+  (LEQ _ e1 e2) -> op2 EVM.LEq e1 e2
+  (GEQ _ e1 e2) -> op2 EVM.GEq e1 e2
+  (Syntax.Annotated.GT _ e1 e2) -> op2 EVM.GT e1 e2
+  (LitBool _ b) -> EVM.Lit (fromIntegral $ fromEnum $ b)
   -- integers
-  (Add _ e1 e2) -> op2 Types.Add e1 e2
-  (Sub _ e1 e2) -> op2 Types.Sub e1 e2
-  (Mul _ e1 e2) -> op2 Types.Mul e1 e2
-  (Div _ e1 e2) -> op2 Types.Div e1 e2
-  (Mod _ e1 e2) -> op2 Types.Mod e1 e2 -- which mod?
-  (Exp _ e1 e2) -> op2 Types.Exp e1 e2
-  (LitInt _ n) -> Types.Lit (fromIntegral n)
+  (Add _ e1 e2) -> op2 EVM.Add e1 e2
+  (Sub _ e1 e2) -> op2 EVM.Sub e1 e2
+  (Mul _ e1 e2) -> op2 EVM.Mul e1 e2
+  (Div _ e1 e2) -> op2 EVM.Div e1 e2
+  (Mod _ e1 e2) -> op2 EVM.Mod e1 e2 -- which mod?
+  (Exp _ e1 e2) -> op2 EVM.Exp e1 e2
+  (LitInt _ n) -> EVM.Lit (fromIntegral n)
   (IntEnv _ env) -> ethEnvToWord env
   -- bounds
-  (IntMin _ n) -> Types.Lit (fromIntegral $ intmin n)
-  (IntMax _ n) -> Types.Lit (fromIntegral $ intmax n)
-  (UIntMin _ n) -> Types.Lit (fromIntegral $ uintmin n)
-  (UIntMax _ n) -> Types.Lit (fromIntegral $ uintmax n)
+  (IntMin _ n) -> EVM.Lit (fromIntegral $ intmin n)
+  (IntMax _ n) -> EVM.Lit (fromIntegral $ intmax n)
+  (UIntMin _ n) -> EVM.Lit (fromIntegral $ uintmin n)
+  (UIntMax _ n) -> EVM.Lit (fromIntegral $ uintmax n)
   (InRange _ t e) -> toExpr layout (inRange t e)
   -- bytestrings
   (Cat _ _ _) -> error "TODO"
   (Slice _ _ _ _) -> error "TODO"
-  -- Types.CopySlice (toExpr start) (Types.Lit 0) -- src and dst offset
-  -- (Types.Add (Types.Sub (toExp end) (toExpr start)) (Types.Lit 0)) -- size
-  -- (toExpr bs) (Types.ConcreteBuf "") -- src and dst
-  (ByStr _ str) -> Types.ConcreteBuf (B8.pack str)
-  (ByLit _ bs) -> Types.ConcreteBuf bs
+  -- EVM.CopySlice (toExpr start) (EVM.Lit 0) -- src and dst offset
+  -- (EVM.Add (EVM.Sub (toExp end) (toExpr start)) (EVM.Lit 0)) -- size
+  -- (toExpr bs) (EVM.ConcreteBuf "") -- src and dst
+  (ByStr _ str) -> EVM.ConcreteBuf (B8.pack str)
+  (ByLit _ bs) -> EVM.ConcreteBuf bs
   (ByEnv _ env) -> ethEnvToBuf env
   -- contracts
   (Create _ _ _) -> error "TODO"
   -- polymorphic
-  (Eq _ SInteger e1 e2) -> op2 Types.Eq e1 e2
-  (Eq _ SBoolean e1 e2) -> op2 Types.Eq e1 e2
+  (Eq _ SInteger e1 e2) -> op2 EVM.Eq e1 e2
+  (Eq _ SBoolean e1 e2) -> op2 EVM.Eq e1 e2
   (Eq _ _ _ _) -> error "unsupported"
 
-  (NEq _ SInteger e1 e2) -> Types.Not $ op2 Types.Eq e1 e2
-  (NEq _ SBoolean e1 e2) -> Types.Not $ op2 Types.Eq e1 e2
+  (NEq _ SInteger e1 e2) -> EVM.Not $ op2 EVM.Eq e1 e2
+  (NEq _ SBoolean e1 e2) -> EVM.Not $ op2 EVM.Eq e1 e2
   (NEq _ _ _ _) -> error "unsupported"
 
   (ITE _ _ _ _) -> error "Internal error: expecting flat expression"
 
-  (Var _ SInteger x) -> (Types.Var (T.pack x)) -- vars can only be words? TODO other types
+  (Var _ SInteger x) -> (EVM.Var (T.pack x)) -- vars can only be words? TODO other types
 
   (TEntry _ _ (Item SInteger _ ref)) ->
     let (addr, slot) = refOffset layout ref in
-    Types.SLoad (litAddr addr) slot Types.AbstractStore
+    EVM.SLoad (litAddr addr) slot EVM.AbstractStore
   e ->  error $ "TODO: " <> show e
 
   where
-    op2 :: forall b c. (Types.Expr (ExprType c) -> Types.Expr (ExprType c) -> b) -> Exp c -> Exp c -> b
+    op2 :: forall b c. (EVM.Expr (ExprType c) -> EVM.Expr (ExprType c) -> b) -> Exp c -> Exp c -> b
     op2 op e1 e2 = op (toExpr layout e1) (toExpr layout e2)
 
 
 -- | Find the input space of an expr list
-inputSpace :: [Types.Expr Types.End] -> [Types.Prop]
+inputSpace :: [EVM.Expr EVM.End] -> [EVM.Prop]
 inputSpace exprs = map aux exprs
   where
-    aux :: Types.Expr Types.End -> Types.Prop
-    aux (Types.Success c _ _) = Types.pand c
+    aux :: EVM.Expr EVM.End -> EVM.Prop
+    aux (EVM.Success c _ _) = EVM.pand c
     aux _ = error "List should only contain success behaviours"
 
 -- | Check whether two lists of behaviours cover exactly the same input space
-checkInputSpaces :: SolverGroup -> VeriOpts -> [Types.Expr Types.End] -> [Types.Expr Types.End] -> IO [EquivResult]
+checkInputSpaces :: SolverGroup -> VeriOpts -> [EVM.Expr EVM.End] -> [EVM.Expr EVM.End] -> IO [EquivResult]
 checkInputSpaces solvers opts l1 l2 = do
   let p1 = inputSpace l1
   let p2 = inputSpace l2
-  let queries = fmap assertProps [ [ Types.PNeg (Types.por p1), Types.por p2 ]
-                               , [ Types.por p1, Types.PNeg (Types.por p2) ] ]
+  let queries = fmap assertProps [ [ EVM.PNeg (EVM.por p1), EVM.por p2 ]
+                               , [ EVM.por p1, EVM.PNeg (EVM.por p2) ] ]
 
   when opts.debug $ forM_ (zip [(1 :: Int)..] queries) $ \(idx, q) -> do
     TL.writeFile

--- a/src/HEVM.hs
+++ b/src/HEVM.hs
@@ -98,7 +98,7 @@ translateAct (Act store contracts) =
 
 translateConstructor :: Layout -> Constructor -> ([EVM.Expr EVM.End], Calldata)
 translateConstructor layout (Constructor cid iface preconds _ _ upds _) =
-  ([EVM.Success (snd calldata <> (fmap (toProp layout) $ preconds)) (returnsToExpr layout Nothing) (updatesToExpr layout cid upds)],
+  ([EVM.Success (snd calldata <> (fmap (toProp layout) $ preconds)) mempty (returnsToExpr layout Nothing) (updatesToExpr layout cid upds)],
    calldata)
 
   where calldata = makeCtrCalldata iface
@@ -118,7 +118,7 @@ translateBehvs layout behvs =
 
 translateBehv :: Layout -> Behaviour -> EVM.Expr EVM.End
 translateBehv layout (Behaviour _ cid _ preconds caseconds _ upds ret) =
-  EVM.Success (fmap (toProp layout) $ preconds <> caseconds) (returnsToExpr layout ret) (rewritesToExpr layout cid upds)
+  EVM.Success (fmap (toProp layout) $ preconds <> caseconds) mempty (returnsToExpr layout ret) (rewritesToExpr layout cid upds)
 
 rewritesToExpr :: Layout -> Id -> [Rewrite] -> EVM.Expr EVM.Storage
 rewritesToExpr layout cid rewrites = foldl (flip $ rewriteToExpr layout cid) EVM.AbstractStore rewrites
@@ -305,7 +305,7 @@ inputSpace :: [EVM.Expr EVM.End] -> [EVM.Prop]
 inputSpace exprs = map aux exprs
   where
     aux :: EVM.Expr EVM.End -> EVM.Prop
-    aux (EVM.Success c _ _) = EVM.pand c
+    aux (EVM.Success c _ _ _) = EVM.pand c
     aux _ = error "List should only contain success behaviours"
 
 -- | Check whether two lists of behaviours cover exactly the same input space

--- a/src/HEVM.hs
+++ b/src/HEVM.hs
@@ -10,6 +10,8 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+
 
 module HEVM where
 
@@ -308,13 +310,13 @@ inputSpace exprs = map aux exprs
 
 -- | Check whether two lists of behaviours cover exactly the same input space
 checkInputSpaces :: SolverGroup -> VeriOpts -> [Types.Expr Types.End] -> [Types.Expr Types.End] -> IO [EquivResult]
-checkInputSpaces solvers _ l1 l2 = do
+checkInputSpaces solvers opts l1 l2 = do
   let p1 = inputSpace l1
   let p2 = inputSpace l2
   let queries = fmap assertProps [ [ Types.PNeg (Types.por p1), Types.por p2 ]
                                , [ Types.por p1, Types.PNeg (Types.por p2) ] ]
 
-  when True $ forM_ (zip [(1 :: Int)..] queries) $ \(idx, q) -> do
+  when opts.debug $ forM_ (zip [(1 :: Int)..] queries) $ \(idx, q) -> do
     TL.writeFile
       ("input-query-" <> show idx <> ".smt2")
       (formatSMT2 q <> "\n\n(check-sat)")

--- a/src/HEVM.hs
+++ b/src/HEVM.hs
@@ -1,446 +1,206 @@
-{-# Language RecordWildCards #-}
-{-# Language TypeApplications #-}
-{-# Language OverloadedStrings #-}
-{-# Language DataKinds #-}
-{-# Language GADTs #-}
-{-# Language MonadComprehensions #-}
-{-# Language ViewPatterns #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
 
-module HEVM where
+module Expr where
 
-import Prelude hiding (lookup, GT, LT)
+import qualified Data.Map as M
+import qualified Data.Text as T
+import qualified Data.ByteString.Char8 as B8 (pack)
 
+import Syntax.Annotated
 import Syntax
-import Syntax.Annotated as Annotated
 
-import Data.ByteString.UTF8 (toString)
-import Data.Text (Text, pack, splitOn)
-import Data.Maybe
-import Data.List hiding (lookup)
-import Data.Map hiding (drop, null, findIndex, splitAt, foldl, foldr, filter)
-import qualified Data.Map as Map
-import Control.Monad.State.Strict (execState)
-import Data.SBV.Control
-import Data.SBV
-import Data.SBV.String ((.++), subStr)
-import Control.Lens hiding (op, pre, (.>))
-import Control.Monad
-import qualified Data.Vector as Vec
+import qualified EVM.Types as Types
+import EVM.Concrete (createAddress)
+import EVM.Expr hiding (op2)
 
-import Print
+-- decompile :: Contract -> ByteString -> IO (Map Interface [Expr End])
 
-import EVM hiding (Query)
-import EVM.VMTest
-import EVM.Solidity hiding (Method)
-import EVM.ABI
-import EVM.Concrete
-import EVM.SymExec
-import EVM.Symbolic
-import EVM.Types (SymWord(..), Buffer(..), Addr(..), toSizzle, litBytes, num, var, w256, SAddr(..))
-
-type SolcJson = Map Text SolcContract
-
-proveBehaviour :: SolcJson -> Behaviour -> Symbolic VerifyResult
-proveBehaviour sources behaviour = do
-  preVm <- initialVm sources' behaviour contractMap
-  query $ do
-    res <- verify preVm Nothing Nothing Nothing (Just postC)
-    case res of
-      Cex tree -> do
-        showCounterexample preVm Nothing
-        return $ Cex tree
-      Timeout tree -> return $ Timeout tree
-      Qed tree -> return $ Qed tree
-
-   where
-     -- todo: deal with ambiguities in contract name
-     sources' = mapKeys (last . splitOn ":") sources
-
-     -- create new addresses for each contract involved
-     -- in the future addresses could be passed through the cli
-     contractMap = fromList $ zipWith
-       (\id' i -> (id', createAddress (Addr 0) i)) (nub $ (Annotated._contract behaviour):(contractsInvolved behaviour)) [0..]
-
-     ctx = mkVmContext sources' behaviour contractMap
-
-     postC (pre, post) = mkPostCondition pre post sources' behaviour contractMap (ctx pre post)
+type family ExprType a where
+  ExprType 'AInteger  = Types.EWord
+  ExprType 'ABoolean  = Types.EWord
+  ExprType 'AByteStr  = Types.Buf
+  ExprType 'AContract = Types.EWord -- adress?
 
 
-interfaceCalldata :: Interface -> Symbolic Buffer
-interfaceCalldata (Interface methodname vars) =
-  let types = fmap (\(Decl typ _) -> typ) vars
-      textsig = pack $ methodname ++ "(" ++ intercalate "," (show <$> types) ++ ")"
-      sig' = litBytes $ selector textsig
-  in SymbolicBuffer . (sig' <>) <$> concatMapM mkabiArg types
-
-initialVm :: SolcJson -> Behaviour -> Map Id Addr -> Symbolic VM
-initialVm sources Behaviour{..} contractMap = do
-  let
-    -- todo; ensure no duplicates
-    this = fromMaybe (error ("Bytecode not found for: " <> show _contract <> ".\nSources available: " <> show (keys sources))) (lookup (pack _contract) sources)
-    addr = fromMaybe (error ("Address not found for: " ++ show _contract ++ ".\nAvailable: " ++ show (keys contractMap))) (lookup _contract contractMap)
-    store = Concrete mempty
-  cd <- interfaceCalldata _interface
-  caller' <- SAddr <$> sWord_
-  value' <- (var "CALLVALUE") <$> sWord_
-  contracts' <- forM (toList contractMap) $
-    \(contractId, addr') -> do
-        let code' = RuntimeCode . ConcreteBuffer $ view runtimeCode $
-              fromMaybe (error "bytecode not found")
-              (lookup (pack contractId) sources)
-        c' <- contractWithStore code' . (Symbolic []) <$> newArray_ Nothing
-        return (addr', c')
-
-  let vm = loadSymVM
-        (RuntimeCode . ConcreteBuffer $ view runtimeCode this)
-        store
-        SymbolicS
-        caller'
-        value'
-        (cd, num $ len cd)
-        & over (env . contracts) (\a -> a <> (fromList contracts'))
-
-  return $ initTx $ execState (loadContract addr) vm
-
-checkPostStorage :: Ctx -> Behaviour -> VM -> VM -> Map Id Addr -> SolcJson -> SBV Bool
-checkPostStorage ctx (Behaviour _ _ _ _ _ _ rewrites _) pre post contractMap solcjson =
-  sAnd $ flip fmap (keys (view (EVM.env . EVM.contracts) post)) $
-    \addr ->
-      case view (EVM.env . EVM.contracts . at addr) pre of
-        Nothing -> sFalse -- TODO: deal with creations
-        Just precontract ->
-          let
-            Just postcontract = view (EVM.env . EVM.contracts . at addr) post
-            prestorage = view EVM.storage precontract
-            poststorage = view EVM.storage postcontract
-          in case (prestorage, poststorage) of
-              (Concrete pre', Concrete post') -> literal $ pre' == post'
-              (Symbolic _ pre', Symbolic _ post') ->
-               let
-                 insertions = updatesFromRewrites $ filter (\a -> addr == get (contractFromRewrite a) contractMap) rewrites
-                 slot update' = let S _ w = calculateSlot ctx solcjson (locFromUpdate update')
-                               in w
-                 insertUpdate :: SArray (WordN 256) (WordN 256) -> StorageUpdate -> SArray (WordN 256) (WordN 256)
-                 insertUpdate store u@(Update SInteger _ e) = writeArray store (slot u) $ sFromIntegral $ symExpInt ctx e
-                 insertUpdate store u@(Update SBoolean _ e) = writeArray store (slot u) $ ite (symExpBool ctx e) 1 0
-                 insertUpdate _ _ = error "bytes unsupported"
-               in post' .== foldl insertUpdate pre' insertions
-              _ -> sFalse
-
-
--- assumes preconditions as well
-mkPostCondition :: VM -> VM -> SolcJson -> Behaviour -> Map Id Addr -> (Ctx, VMResult) -> SBool
-mkPostCondition preVm postVm solcjson
-  b@(Behaviour _ _ _ preCond ifs postCond _ returns)
-  contractMap
-  (ctx, vmResult) =
-    let storageConstraints = checkPostStorage ctx b preVm postVm contractMap solcjson
-        preCondPass = symExpBool ctx (mconcat (preCond <> ifs))
-        preCondFail = symExpBool ctx (Neg nowhere (mconcat preCond))
-        
-        postCond' = symExpBool ctx (mconcat postCond)
-        (actual, reverted) = case vmResult of
-          VMSuccess (ConcreteBuffer msg) -> (litBytes msg, sFalse)
-          VMSuccess (SymbolicBuffer msg) -> (msg, sFalse)
-          VMFailure (Revert _) -> ([], sTrue)
-          _ -> ([], sFalse)
-        expected = maybe [] (toSymBytes . symExp ctx) returns
-
-    in (preCondPass .=>
-        (postCond' .&& storageConstraints .&& sNot reverted .&& (actual .== expected))) .&&
-       (preCondFail .=> reverted) -- TODO shall we check for postCond' .&& storageConstraints here?
-
--- | Locate the variables refered to in the act-spec in the vm
-mkVmContext :: SolcJson -> Behaviour -> Map Id Addr -> VM -> VM -> (Ctx, VMResult)
-mkVmContext solcjson b@(Behaviour method c1 (Interface _ decls) _ _ _ updates _) contractMap pre post =
-  let args = fromList $ locateCalldata b decls (fst $ view (state . calldata) pre) <$> decls
-      env' = makeVmEnv b pre
-      -- we should always have a result after executing the vm fully.
-      Just res = view result post
-      -- add storage entries to the 'store' map as we go along
-      ctx = foldl
-       (\ctx'@(Ctx c m a s e) update' ->
-         let
-           (name, entry) = locateStorage ctx' solcjson contractMap method (pre, post) update'
-         in Ctx c m a (Map.insert name entry s) e)
-       (Ctx c1 method args mempty env') updates
-  in (ctx, res)
-
-
-makeVmEnv :: Behaviour -> VM -> Map Id SActType
-makeVmEnv (Behaviour method c1 _ _ _ _ _ _) vm =
-  fromList
-    [ Caller    |- SymInteger (sFromIntegral $ saddressWord160 (view (state . caller) vm))
-    , Callvalue |- let S _ w = view (state . callvalue) vm
-                   in SymInteger (sFromIntegral w)
-    , Calldepth |- SymInteger (num $ length (view frames vm))
-     -- the following environment variables are always concrete in hevm right now
-    , Origin    |- SymInteger (num $ addressWord160 (view (tx . origin) vm))
-    , Difficulty |- SymInteger (num $ view (block . difficulty) vm)
-    , Chainid |- SymInteger (num $ view (env . chainId) vm)
-    , Timestamp |- let S _ w = view (block . timestamp) vm
-                   in SymInteger (sFromIntegral w)
-    , This |- SymInteger (num $ addressWord160 (view (state . contract) vm))
-    , Nonce |- let
-                 maybeContract = view (env . contracts . at (view (state . contract) vm)) vm
-               in SymInteger $ maybe 1 (num . view nonce) maybeContract
-
-      -- and this one does not even give a reasonable result
---    , Blockhash |- error "blockhash not available in hevm right now"
-    ]
+type Layout = M.Map Id (M.Map Id (Types.Addr, Integer))
+  
+slotMap :: [Contract] -> Layout
+slotMap contracts =
+  foldl (\layout (Contract Constructor{..} _) ->
+            let addr = createAddress (Types.Addr 0) 0 in -- for now all contracts have the same address
+            let varmap = addVars addr _initialStorage in
+              M.insert _cname varmap layout
+        ) M.empty contracts
   where
-    (|-) a b = (nameFromEnv c1 method a, b)
-
--- | Locate the variables refered to in the act-spec in the vm
-locateStorage :: Ctx -> SolcJson -> Map Id Addr -> Method -> (VM,VM) -> Rewrite -> (Id, (SActType, SActType))
-locateStorage ctx@(Ctx c _ _ _ _) solcjson contractMap method (pre, post) item =
-  let item' = locFromRewrite item
-      addr = get (contractFromRewrite item) contractMap
-
-      Just preContract = view (env . contracts . at addr) pre
-      Just postContract = view (env . contracts . at addr) post
-
-      Just (S _ preValue) = readStorage (view storage preContract) (calculateSlot ctx solcjson item')
-      Just (S _ postValue) = readStorage (view storage postContract) (calculateSlot ctx solcjson item')
-
-      name :: StorageLocation -> Id
-      name (Loc _ i) = nameFromItem c method i
-
-  in (name item',  (SymInteger (sFromIntegral preValue), SymInteger (sFromIntegral postValue)))
-
-calculateSlot :: Ctx -> SolcJson -> StorageLocation -> SymWord
-calculateSlot ctx solcjson loc =
-  -- TODO: packing with offset
-  let
-    source = get (pack (contractFromLoc loc)) solcjson
-    layout = fromMaybe (error "internal error: no storageLayout") $ _storageLayout source
-    StorageItem _ _ slot = get (pack (idFromLocation loc)) layout
-    slotword = sFromIntegral (literal (fromIntegral slot :: Integer))
-    indexers = symExp ctx <$> ixsFromLocation loc
-  in var (idFromLocation loc) $
-     if null indexers
-     then slotword
-     else foldl (\a b -> keccak' . SymbolicBuffer $ toBytes a <> toSymBytes b) slotword indexers
+    addVars addr upds =
+      foldl (\layout (upd, i) -> M.insert (idFromUpdate upd) (addr, i) layout) M.empty $ zip upds [0..]
 
 
-locateCalldata :: Behaviour -> [Decl] -> Buffer -> Decl -> (Id, SActType)
-locateCalldata b decls calldata' d@(Decl typ name) =
-  if any (\(Decl typ' _) -> abiKind typ' /= Static) decls
-  then error "dynamic calldata args currently unsupported"
-  else (nameFromDecl (Annotated._contract b) (_name b) d, val)
+translateAct :: Act -> [Types.Expr Types.End]
+translateAct (Act _ contracts) =
+  let slots = slotMap contracts in
+  concatMap (\(Contract _ behvs) -> map (translateBehv slots) behvs) contracts
 
+  
+translateBehv :: Layout -> Behaviour -> Types.Expr Types.End
+translateBehv layout (Behaviour _ cid _ preconds caseconds _ upds ret) =  
+  Types.Success (fmap toProp $ preconds <> caseconds) (returnsToExpr ret) (rewritesToExpr layout cid upds)
+
+rewritesToExpr :: Layout -> Id -> [Rewrite] -> Types.Expr Types.Storage
+rewritesToExpr layout cid rewrites = foldl (flip $ rewriteToExpr layout cid) Types.AbstractStore rewrites
+
+rewriteToExpr :: Layout -> Id -> Rewrite -> Types.Expr Types.Storage -> Types.Expr Types.Storage
+rewriteToExpr _ _ (Constant _) state = state
+rewriteToExpr layout cid (Rewrite (Update typ i@(Item _ _ ref) e)) state =
+  case typ of
+    SInteger -> Types.SStore (Types.Lit $ fromIntegral addr) offset e' state
+    SBoolean -> Types.SStore (Types.Lit $ fromIntegral addr) offset e' state
+    SByteStr -> error "Bytestrings not supported"
+    SContract -> error "Contracts not supported"
   where
-    -- every argument is static right now; length is always 32
-    offset = w256 . fromIntegral $ 4 + 32 * fromMaybe
-          (error ("internal error: could not find calldata var: "
-              ++ name ++ " in interface declaration"))
-          (elemIndex d decls)
+    (addr, slot) = getSlot layout cid (idFromItem i)
+    offset = offsetFromRef slot ref
+    e' = toExpr e
 
-    val = case fromAbiType typ of
-      -- all integers are 32 bytes
-      AInteger -> let S _ w = readSWord offset calldata'
-                 in SymInteger $ sFromIntegral w
-      -- interpret all nonzero values as boolean true
-      ABoolean -> SymBool $ readSWord offset calldata' ./= 0
-      _ -> error "TODO: support bytes"
+returnsToExpr :: Maybe TypedExp -> Types.Expr Types.Buf
+returnsToExpr Nothing = Types.ConcreteBuf ""
+returnsToExpr (Just r) = typedExpToBuf r
 
--- | Embed an SActType as a list of symbolic bytes
-toSymBytes :: SActType -> [SWord 8]
-toSymBytes (SymInteger i) = toBytes (sFromIntegral i :: SWord 256)
-toSymBytes (SymBool i) = ite i (toBytes (1 :: SWord 256)) (toBytes (0 :: SWord 256))
-toSymBytes (SymBytes _) = error "unsupported"
+offsetFromRef :: Integer -> StorageRef -> Types.Expr Types.EWord
+offsetFromRef slot (SVar _ _ _) = Types.Lit $ fromIntegral slot
+offsetFromRef slot (SMapping _ _ ixs) = 
+  foldl (\slot i -> Types.keccak ((wordToBuf slot) <> (typedExpToBuf i))) (Types.Lit $ fromIntegral slot) ixs
+offsetFromRef _ (SField _ _ _ _) = error "TODO contracts not supported"
 
+wordToBuf :: Types.Expr Types.EWord -> Types.Expr Types.Buf
+wordToBuf w = Types.WriteWord (Types.Lit 0) w (Types.ConcreteBuf "")
 
--- | Convenience functions for generating symbolic byte strings
-freshbytes32 :: Symbolic [SWord 8]
-freshbytes32 = toBytes <$> free_ @ (WordN 256)
+wordToProp :: Types.Expr Types.EWord -> Types.Prop
+wordToProp w = Types.PNeg (Types.PEq w (Types.Lit 0))
+  
+typedExpToBuf :: TypedExp -> Types.Expr Types.Buf
+typedExpToBuf expr =
+  case expr of
+    TExp styp e -> expToBuf styp e
+    
+expToBuf :: forall a. SType a -> Exp a  -> Types.Expr Types.Buf
+expToBuf styp e =
+  case styp of
+    SInteger -> Types.WriteWord (Types.Lit 0) (toExpr e) (Types.ConcreteBuf "")
+    SBoolean -> Types.WriteWord (Types.Lit 0) (toExpr e) (Types.ConcreteBuf "")
+    SByteStr -> toExpr e
+    SContract -> error "Internal error: expecting primitive type"
 
+getSlot :: Layout -> Id -> Id -> (Types.Addr, Integer)
+getSlot layout cid name =
+  case M.lookup cid layout of
+    Just m -> case M.lookup name m of
+      Just v -> v
+      Nothing -> error "Internal error: invalid variable name"
+    Nothing -> error "Internal error: invalid contract name"
 
--- | Adapted from SymExec.symAbiArg to fit into the `Symbolic` monad instead of
--- `Query`.
-mkabiArg :: AbiType -> Symbolic [SWord 8]
-mkabiArg (AbiUIntType n)  | n `mod` 8 == 0 && n <= 256 = freshbytes32
-                          | otherwise = error "bad type"
-mkabiArg (AbiIntType n)   | n `mod` 8 == 0 && n <= 256 = freshbytes32
-                          | otherwise = error "bad type"
-mkabiArg AbiBoolType     = freshbytes32
-mkabiArg AbiAddressType  = freshbytes32
-mkabiArg (AbiBytesType n) | n <= 32 = freshbytes32
-                          | otherwise = error "bad type"
-mkabiArg (AbiArrayType leng typ) =
-  do args <- concat <$> replicateM leng (mkabiArg typ)
-     return (litBytes (encodeAbiValue (AbiUInt 256 (fromIntegral leng))) <> args)
-mkabiArg (AbiTupleType tuple) = concat <$> mapM mkabiArg (Vec.toList tuple)
-mkabiArg n =
-  error $ "TODO: symbolic abiencoding for"
-    <> show n <> "."
+ethEnvToWord :: EthEnv -> Types.Expr Types.EWord
+ethEnvToWord Callvalue = Types.CallValue 0
+ethEnvToWord Caller = Types.Caller 0
+ethEnvToWord Origin = Types.Origin
+ethEnvToWord Blocknumber = Types.BlockNumber
+ethEnvToWord Blockhash = error "TODO" -- Types.BlockHash ??  missing EWord!
+ethEnvToWord Chainid = Types.ChainId
+ethEnvToWord Gaslimit = Types.GasLimit
+ethEnvToWord Coinbase = Types.Coinbase
+ethEnvToWord Timestamp = Types.Timestamp
+ethEnvToWord This = error "TODO"
+ethEnvToWord Nonce = error "TODO"
+ethEnvToWord Calldepth = error "TODO"
+ethEnvToWord Difficulty = error "TODO"
 
--- | Literal keccak when input is concrete, uninterpreted function when input symbolic.
-keccak' :: Buffer -> SWord 256
-keccak' (SymbolicBuffer bytes) = case maybeLitBytes bytes of
-  Nothing -> symkeccak' bytes
-  Just bs -> keccak' (ConcreteBuffer bs)
-keccak' (ConcreteBuffer bytes) = literal $ toSizzle $ wordValue $ keccakBlob bytes
+ethEnvToBuf :: EthEnv -> Types.Expr Types.Buf
+ethEnvToBuf _ = error "Internal error: there are no bytestring environment values"
 
---- Symbolic Expression Generation ---
+toProp :: Exp ABoolean -> Types.Prop
+toProp (And _ e1 e2) = pop2 Types.PAnd e1 e2
+toProp (Or _ e1 e2) = pop2 Types.POr e1 e2
+toProp (Impl _ e1 e2) = pop2 Types.PImpl e1 e2
+toProp (Neg _ e1) = Types.PNeg (toProp e1)
+toProp (Syntax.Annotated.LT _ e1 e2) = op2 Types.PLT e1 e2
+toProp (LEQ _ e1 e2) = op2 Types.PLEq e1 e2
+toProp (GEQ _ e1 e2) = op2 Types.PGEq e1 e2
+toProp (Syntax.Annotated.GT _ e1 e2) = op2 Types.PGT e1 e2
+toProp (LitBool _ b) = Types.PBool b
+toProp (Eq _ SInteger e1 e2) = Types.PEq (toExpr e1) (toExpr e2)
+toProp (Eq _ SBoolean e1 e2) = Types.PEq (toExpr e1) (toExpr e2)
+toProp (NEq _ SInteger e1 e2) = Types.PNeg $ Types.PEq (toExpr e1) (toExpr e2)
+toProp (NEq _ SBoolean e1 e2) = Types.PNeg $ Types.PEq (toExpr e1) (toExpr e2)
+toProp (ITE _ _ _ _) = error "Internal error: expecting flat expression"
+toProp (Var _ _ _) = error "TODO" -- (Types.Var (T.pack x)) -- vars can only be words? TODO other types
+toProp (TEntry _ _ _) = error "TODO" -- Types.SLoad addr idx 
 
-data Ctx = Ctx ContractName Method Args HEVM.Storage HEVM.Env
-  deriving (Show)
+toExpr :: forall a. Exp a -> Types.Expr (ExprType a)
+-- booleans
+toExpr (And _ e1 e2) = op2 Types.And e1 e2
+toExpr (Or _ e1 e2) = op2 Types.Or e1 e2
+toExpr (Impl _ e1 e2) = op2 (\x y -> Types.Or (Types.Not x) y) e1 e2
+toExpr (Neg _ e1) = Types.Not (toExpr e1)
+toExpr (Syntax.Annotated.LT _ e1 e2) = op2 Types.LT e1 e2
+toExpr (LEQ _ e1 e2) = op2 Types.LEq e1 e2
+toExpr (GEQ _ e1 e2) = op2 Types.GEq e1 e2
+toExpr (Syntax.Annotated.GT _ e1 e2) = op2 Types.GT e1 e2
+toExpr (LitBool _ b) = Types.Lit (fromIntegral $ fromEnum $ b)
+-- integers
+toExpr (Add _ e1 e2) = op2 Types.Add e1 e2
+toExpr (Sub _ e1 e2) = op2 Types.Sub e1 e2
+toExpr (Mul _ e1 e2) = op2 Types.Mul e1 e2
+toExpr (Div _ e1 e2) = op2 Types.Div e1 e2
+toExpr (Mod _ e1 e2) = op2 Types.Mod e1 e2 -- which mod?
+toExpr (Exp _ e1 e2) = op2 Types.Exp e1 e2
+toExpr (LitInt _ n) = Types.Lit (fromIntegral n)
+toExpr (IntEnv _ env) = ethEnvToWord env
+-- bounds
+toExpr (IntMin _ n) = Types.Lit (fromIntegral $ intmin n)
+toExpr (IntMax _ n) = Types.Lit (fromIntegral $ intmax n)
+toExpr (UIntMin _ n) = Types.Lit (fromIntegral $ uintmin n)
+toExpr (UIntMax _ n) = Types.Lit (fromIntegral $ uintmax n)
+-- bytestrings
+toExpr (Cat _ e1 e2) = error "TODO"
+toExpr (Slice _ bs start end) = error "TODO"
+  -- Types.CopySlice (toExpr start) (Types.Lit 0) -- src and dst offset
+  -- (Types.Add (Types.Sub (toExp end) (toExpr start)) (Types.Lit 0)) -- size
+  -- (toExpr bs) (Types.ConcreteBuf "") -- src and dst  
+toExpr (ByStr _ str) = Types.ConcreteBuf (B8.pack str)
+toExpr (ByLit _ bs) = Types.ConcreteBuf bs
+toExpr (ByEnv _ env) = ethEnvToBuf env
+-- contracts
+toExpr (Create _ typ cid args) = error "TODO"
+-- polymorphic
+toExpr (Eq _ SInteger e1 e2) = Types.Eq (toExpr e1) (toExpr e2)
+toExpr (Eq _ SBoolean e1 e2) = Types.Eq (toExpr e1) (toExpr e2)
 
-data SActType
-  = SymInteger (SBV Integer)
-  | SymBool (SBV Bool)
-  | SymBytes (SBV String)
-  deriving (Show)
+toExpr (NEq _ SInteger e1 e2) = Types.Not $ Types.Eq (toExpr e1) (toExpr e2)
+toExpr (NEq _ SBoolean e1 e2) = Types.Not $ Types.Eq (toExpr e1) (toExpr e2)
 
-type ContractName = Id
-type Method = Id
-type Args = Map Id SActType
-type Storage = Map Id (SActType, SActType)
-type Env = Map Id SActType
+toExpr (ITE _ _ _ _) = error "Internal error: expecting flat expression"
 
-symExp :: Ctx -> TypedExp -> SActType
-symExp ctx (TExp t e) = case t of
-  SInteger -> SymInteger $ symExpInt   ctx e
-  SBoolean -> SymBool    $ symExpBool  ctx e
-  SByteStr -> SymBytes   $ symExpBytes ctx e
-  SContract -> error "calls not supported"
+toExpr (Var _ SInteger x) = (Types.Var (T.pack x)) -- vars can only be words? TODO other types
 
-symExpBool :: Ctx -> Exp ABoolean -> SBV Bool
-symExpBool ctx@(Ctx c m args store _) e = case e of
-  And _ a b   -> symExpBool ctx a .&& symExpBool ctx b
-  Or _ a b    -> symExpBool ctx a .|| symExpBool ctx b
-  Impl _ a b  -> symExpBool ctx a .=> symExpBool ctx b
-  LT _ a b    -> symExpInt ctx a .< symExpInt ctx b
-  LEQ _ a b   -> symExpInt ctx a .<= symExpInt ctx b
-  GT _ a b    -> symExpInt ctx a .> symExpInt ctx b
-  GEQ _ a b   -> symExpInt ctx a .>= symExpInt ctx b
-  NEq p t a b   -> sNot (symExpBool ctx (Eq p t a b))
-  Neg _ a     -> sNot (symExpBool ctx a)
-  LitBool _ a -> literal a
-  Var _ _ a   -> get (nameFromArg c m a) (catBools args)
-  TEntry _ t a -> get (nameFromItem c m a) (catBools $ timeStore t store)
-  ITE _ x y z -> ite (symExpBool ctx x) (symExpBool ctx y) (symExpBool ctx z)
-  Eq _ SInteger a b -> symExpInt  ctx a .== symExpInt  ctx b
-  Eq _ SBoolean a b -> symExpBool  ctx a .== symExpBool  ctx b
-  Eq _ SByteStr a b -> symExpBytes  ctx a .== symExpBytes  ctx b
-  Eq _ SContract _ _ -> error "calls not supported"
-  Create _ _ _ _ -> error "calls not supported"
-
-symExpInt :: Ctx -> Exp AInteger -> SBV Integer
-symExpInt ctx@(Ctx c m args store environment) e = case e of
-  Add _ a b   -> symExpInt ctx a + symExpInt ctx b
-  Sub _ a b   -> symExpInt ctx a - symExpInt ctx b
-  Mul _ a b   -> symExpInt ctx a * symExpInt ctx b
-  Div _ a b   -> symExpInt ctx a `sDiv` symExpInt ctx b
-  Mod _ a b   -> symExpInt ctx a `sMod` symExpInt ctx b
-  Exp _ a b   -> symExpInt ctx a .^ symExpInt ctx b
-  LitInt _ a  -> literal a
-  IntMin _ a  -> literal $ intmin a
-  IntMax _ a  -> literal $ intmax a
-  UIntMin _ a -> literal $ uintmin a
-  UIntMax _ a -> literal $ uintmax a
-  Var _ _ a   -> get (nameFromArg c m a) (catInts args)
-  TEntry _ t a -> get (nameFromItem c m a) (catInts $ timeStore t store)
-  IntEnv _ a -> get (nameFromEnv c m a) (catInts environment)
-  ITE _ x y z -> ite (symExpBool ctx x) (symExpInt ctx y) (symExpInt ctx z)
-  Create _ _ _ _ -> error "calls not supported"
-
-symExpBytes :: Ctx -> Exp AByteStr -> SBV String
-symExpBytes ctx@(Ctx c m args store environment) e = case e of
-  Cat _ a b -> symExpBytes ctx a .++ symExpBytes ctx b
-  Var _ _ a -> get (nameFromArg c m a) (catBytes args)
-  ByStr _ a -> literal a
-  ByLit _ a -> literal $ toString a
-  TEntry _ t a -> get (nameFromItem c m a) (catBytes $ timeStore t store)
-  Slice _ a x y -> subStr (symExpBytes ctx a) (symExpInt ctx x) (symExpInt ctx y)
-  ByEnv _ a -> get (nameFromEnv c m a) (catBytes environment)
-  ITE _ x y z -> ite (symExpBool ctx x) (symExpBytes ctx y) (symExpBytes ctx z)
-  Create _ _ _ _ -> error "calls not supported"
-
-timeStore :: When -> HEVM.Storage -> Map Id SActType
-timeStore Pre  s = fst <$> s
-timeStore Post s = snd <$> s
-
--- *** SMT Variable Names *** --
-
-nameFromStorageRef :: ContractName -> Method -> StorageRef -> Id
-nameFromStorageRef c method (SVar _ _ name) = c @@ method @@ name
-nameFromStorageRef c method (SMapping _ e ixs) = nameFromStorageRef c method e <> showIxs
-  where
-    showIxs = intercalate "-" $ "" : fmap (nameFromTypedExp c method) ixs
-nameFromStorageRef _ _ (SField _ _ _ _) = error "contracts not supported"
-
-nameFromItem :: ContractName -> Method -> TStorageItem a -> Id
-nameFromItem c method (Item _ _ e) = nameFromStorageRef c method e
-
-nameFromTypedExp :: ContractName -> Method -> TypedExp -> Id
-nameFromTypedExp c method (TExp _ e) = nameFromExp c method e
-
-nameFromExp :: ContractName -> Method -> Exp a -> Id
-nameFromExp c m e = case e of
-  Add _ a b   -> nameFromExp c m a <> "+" <> nameFromExp c m b
-  Sub _ a b   -> nameFromExp c m a <> "-" <> nameFromExp c m b
-  Mul _ a b   -> nameFromExp c m a <> "*" <> nameFromExp c m b
-  Div _ a b   -> nameFromExp c m a <> "/" <> nameFromExp c m b
-  Mod _ a b   -> nameFromExp c m a <> "%" <> nameFromExp c m b
-  Exp _ a b   -> nameFromExp c m a <> "^" <> nameFromExp c m b
-  LitInt _ a  -> show a
-  IntMin _ a  -> show $ intmin a
-  IntMax _ a  -> show $ intmax a
-  UIntMin _ a -> show $ uintmin a
-  UIntMax _ a -> show $ uintmax a
-  IntEnv _ a -> nameFromEnv c m a
-
-  And _ a b   -> nameFromExp c m a <> "&&" <> nameFromExp c m b
-  Or _ a b    -> nameFromExp c m a <> "|" <> nameFromExp c m b
-  Impl _ a b  -> nameFromExp c m a <> "=>" <> nameFromExp c m b
-  LT _ a b    -> nameFromExp c m a <> "<" <> nameFromExp c m b
-  LEQ _ a b   -> nameFromExp c m a <> "<=" <> nameFromExp c m b
-  GT _ a b    -> nameFromExp c m a <> ">" <> nameFromExp c m b
-  GEQ _ a b   -> nameFromExp c m a <> ">=" <> nameFromExp c m b
-  Neg _ a     -> "~" <> nameFromExp c m a
-  LitBool _ a -> show a
-  Eq _ _ a b    -> nameFromExp c m a <> "=="  <> nameFromExp c m b
-  NEq _ _ a b   -> nameFromExp c m a <> "=/=" <> nameFromExp c m b
-  Cat _ a b -> nameFromExp c m a <> "++" <> nameFromExp c m b
-  ByStr _ a -> show a
-  ByLit _ a -> show a
-  Slice _ a x y -> nameFromExp c m a <> "[" <> show x <> ":" <> show y <> "]"
-  ByEnv _ a -> nameFromEnv c m a
-
-  Var _ _ a -> nameFromArg c m a
-  TEntry _ _ a -> nameFromItem c m a
-  ITE _ x y z -> "if-" <> nameFromExp c m x <> "-then-" <> nameFromExp c m y <> "-else-" <> nameFromExp c m z
-
-  Create _ _ _ _ -> error "calls not supported"
-
-nameFromDecl :: ContractName -> Method -> Decl -> Id
-nameFromDecl c m (Decl _ name) = nameFromArg c m name
-
-nameFromArg :: ContractName -> Method -> Id -> Id
-nameFromArg c method name = c @@ method @@ name
-
-nameFromEnv :: ContractName -> Method -> EthEnv -> Id
-nameFromEnv c method e = c @@ method @@ (prettyEnv e)
-
-(@@) :: (Show a, Show b) => a -> b -> Id
-x @@ y = show x <> "_" <> show y
-
--- *** Utils *** --
+-- toExpr (TEntry _ SInteger item) = Types.SLoad addr idx 
 
 
-get :: (Show a, Ord a, Show b) => a -> Map a b -> b
-get name vars = fromMaybe (error (show name <> " not found in " <> show vars)) $ Map.lookup name vars
+-- TODO index is the slot number or the address ?
 
-catInts :: Map Id SActType -> Map Id (SBV Integer)
-catInts m = Map.fromList [(name, i) | (name, SymInteger i) <- Map.toList m]
 
-catBools :: Map Id SActType -> Map Id (SBV Bool)
-catBools m = Map.fromList [(name, i) | (name, SymBool i) <- Map.toList m]
-
-catBytes :: Map Id SActType -> Map Id (SBV String)
-catBytes m = Map.fromList [(name, i) | (name, SymBytes i) <- Map.toList m]
-
-concatMapM :: Monad m => (a -> m [b]) -> [a] -> m [b]
-concatMapM f xs = fmap concat (mapM f xs)
+op2 :: forall a b. (Types.Expr (ExprType b) -> Types.Expr (ExprType b) -> a) -> Exp b -> Exp b -> a
+op2 op e1 e2 = op (toExpr e1) (toExpr e2)
+  
+pop2 :: forall a. (Types.Prop -> Types.Prop -> a) -> Exp ABoolean -> Exp ABoolean -> a
+pop2 op e1 e2 = op (toProp e1) (toProp e2)

--- a/src/Lex.x
+++ b/src/Lex.x
@@ -37,6 +37,7 @@ tokens :-
   storage                               { mk STORAGE }
   noop                                  { mk NOOP }
 
+  iff $white+ in $white+ range          { mk IFFINRANGE }
   inRange                               { mk INRANGE }
   iff                                   { mk IFF }
   and                                   { mk AND }
@@ -131,6 +132,7 @@ data LEX =
   | RETURNS
   | STORAGE
   | NOOP
+  | IFFINRANGE
   | INRANGE
   | IFF
   | AND

--- a/src/Lex.x
+++ b/src/Lex.x
@@ -37,7 +37,7 @@ tokens :-
   storage                               { mk STORAGE }
   noop                                  { mk NOOP }
 
-  iff $white+ in $white+ range          { mk IFFINRANGE }
+  inRange                               { mk INRANGE }
   iff                                   { mk IFF }
   and                                   { mk AND }
   not                                   { mk NOT }
@@ -131,7 +131,7 @@ data LEX =
   | RETURNS
   | STORAGE
   | NOOP
-  | IFFINRANGE
+  | INRANGE
   | IFF
   | AND
   | NOT

--- a/src/Parse.y
+++ b/src/Parse.y
@@ -26,7 +26,7 @@ import Data.Validation
   'returns'                   { L RETURNS _ }
   'storage'                   { L STORAGE _ }
   'noop'                      { L NOOP _ }
-  'iff in range'              { L IFFINRANGE _ }
+  'inRange'                   { L INRANGE _ }
   'iff'                       { L IFF _ }
   'and'                       { L AND _ }
   'not'                       { L NOT _ }
@@ -197,7 +197,6 @@ Returns : 'returns' Expr                              { $2 }
 Storage : 'storage' nonempty(Store)                   { $2 }
 
 Precondition : 'iff' nonempty(Expr)                   { Iff (posn $1) $2 }
-             | 'iff in range' AbiType nonempty(Expr)  { IffIn (posn $1) $2 $3 }
 
 Store : Entry '=>' Expr                               { Rewrite $1 $3 }
       | Entry                                         { Constant $1 }
@@ -245,6 +244,7 @@ SlotType : 'mapping' '(' MappingArgs ')'              { (uncurry StorageMapping)
 MappingArgs : Type '=>' Type                          { ($1 NonEmpty.:| [], $3) }
             | Type '=>' 'mapping' '(' MappingArgs ')' { (NonEmpty.cons $1 (fst $5), snd $5)  }
 
+
 Expr : '(' Expr ')'                                   { $2 }
 
   -- terminals
@@ -265,7 +265,7 @@ Expr : '(' Expr ')'                                   { $2 }
   | Expr '>'   Expr                                   { EGT   (posn $2) $1 $3 }
   | 'true'                                            { BoolLit (posn $1) True }
   | 'false'                                           { BoolLit (posn $1) False }
-
+  | 'inRange' '(' AbiType ',' Expr ')'                { EInRange (posn $1) $3 $5 }
   -- integer expressions
   | Expr '+'   Expr                                   { EAdd (posn $2)  $1 $3 }
   | Expr '-'   Expr                                   { ESub (posn $2)  $1 $3 }

--- a/src/Parse.y
+++ b/src/Parse.y
@@ -26,6 +26,7 @@ import Data.Validation
   'returns'                   { L RETURNS _ }
   'storage'                   { L STORAGE _ }
   'noop'                      { L NOOP _ }
+  'iff in range'              { L IFFINRANGE _ }
   'inRange'                   { L INRANGE _ }
   'iff'                       { L IFF _ }
   'and'                       { L AND _ }
@@ -197,6 +198,7 @@ Returns : 'returns' Expr                              { $2 }
 Storage : 'storage' nonempty(Store)                   { $2 }
 
 Precondition : 'iff' nonempty(Expr)                   { Iff (posn $1) $2 }
+             | 'iff in range' AbiType nonempty(Expr)  { IffIn (posn $1) $2 $3 }
 
 Store : Entry '=>' Expr                               { Rewrite $1 $3 }
       | Entry                                         { Constant $1 }

--- a/src/Print.hs
+++ b/src/Print.hs
@@ -68,9 +68,10 @@ prettyExp e = case e of
   Mod _ a b -> print2 "%" a b
   Exp _ a b -> print2 "^" a b
   UIntMax _ a -> show $ uintmax a
-  UIntMin _ a -> show $ uintmin a
+  UIntMin _ a -> show $ uintmax a
   IntMax _ a -> show $ intmax a
   IntMin _ a -> show $ intmin a
+  InRange _ a b -> "inrange(" <> show a <> ", " <> show b <> ")"
   LitInt _ a -> show a
   IntEnv _ a -> prettyEnv a
 
@@ -164,6 +165,7 @@ prettyInvPred = prettyExp . untime . fst
       IntMax p a  -> IntMax p a
       UIntMin p a -> UIntMin p a
       UIntMax p a -> UIntMax p a
+      InRange p a b -> InRange p a (untime b)
       LitBool p a -> LitBool p a
       Create p f xs -> Create p f (fmap untimeTyped xs)
       IntEnv p a  -> IntEnv p a

--- a/src/Print.hs
+++ b/src/Print.hs
@@ -68,7 +68,7 @@ prettyExp e = case e of
   Mod _ a b -> print2 "%" a b
   Exp _ a b -> print2 "^" a b
   UIntMax _ a -> show $ uintmax a
-  UIntMin _ a -> show $ uintmax a
+  UIntMin _ a -> show $ uintmin a
   IntMax _ a -> show $ intmax a
   IntMin _ a -> show $ intmin a
   InRange _ a b -> "inrange(" <> show a <> ", " <> show b <> ")"

--- a/src/Print.hs
+++ b/src/Print.hs
@@ -82,7 +82,7 @@ prettyExp e = case e of
   ByEnv _ a -> prettyEnv a
 
   -- contracts
-  Create _ _ f ixs -> f <> "(" <> (intercalate "," $ fmap prettyTypedExp ixs) <> ")"
+  Create _ f ixs -> f <> "(" <> (intercalate "," $ fmap prettyTypedExp ixs) <> ")"
   
   --polymorphic
   ITE _ a b c -> "(if " <> prettyExp a <> " then " <> prettyExp b <> " else " <> prettyExp c <> ")"
@@ -165,7 +165,7 @@ prettyInvPred = prettyExp . untime . fst
       UIntMin p a -> UIntMin p a
       UIntMax p a -> UIntMax p a
       LitBool p a -> LitBool p a
-      Create p t f xs -> Create p t f (fmap untimeTyped xs)
+      Create p f xs -> Create p f (fmap untimeTyped xs)
       IntEnv p a  -> IntEnv p a
       ByEnv p a   -> ByEnv p a
       ITE p x y z -> ITE p (untime x) (untime y) (untime z)

--- a/src/SMT.hs
+++ b/src/SMT.hs
@@ -51,15 +51,10 @@ import Syntax.Annotated
 import Print
 import Type (defaultStore)
 
+import EVM.Solvers (Solver(..))
+
 --- ** Data ** ---
 
-
-data Solver = Z3 | CVC4
-  deriving Eq
-
-instance Show Solver where
-  show Z3 = "z3"
-  show CVC4 = "cvc4"
 
 data SMTConfig = SMTConfig
   { _solver :: Solver
@@ -340,12 +335,13 @@ solverArgs (SMTConfig solver timeout _) = case solver of
   Z3 ->
     [ "-in"
     , "-t:" <> show timeout]
-  CVC4 ->
+  CVC5 ->
     [ "--lang=smt"
     , "--interactive"
     , "--no-interactive-prompt"
     , "--produce-models"
     , "--tlimit-per=" <> show timeout]
+  _ -> error "Unsupported solver"
 
 -- | Spawns a solver instance, and sets the various global config options that we use for our queries
 spawnSolver :: SMTConfig -> IO SolverInstance

--- a/src/SMT.hs
+++ b/src/SMT.hs
@@ -338,8 +338,8 @@ solverArgs (SMTConfig solver timeout _) = case solver of
   CVC5 ->
     [ "--lang=smt"
     , "--interactive"
-    , "--no-interactive-prompt"
     , "--produce-models"
+    , "--print-success"
     , "--tlimit-per=" <> show timeout]
   _ -> error "Unsupported solver"
 
@@ -367,8 +367,8 @@ sendLines solver smt = case smt of
   hd : tl -> do
     suc <- sendCommand solver hd
     if suc == "success"
-       then sendLines solver tl
-       else pure (Just suc)
+    then sendLines solver tl
+    else pure (Just suc)
 
 -- | Sends a single command to the solver, returns the first available line from the output buffer
 sendCommand :: SolverInstance -> SMT2 -> IO String

--- a/src/SMT.hs
+++ b/src/SMT.hs
@@ -599,7 +599,7 @@ expToSMT2 expr = case expr of
   ByEnv _ a -> pure $ prettyEnv a
 
   -- contracts
-  Create _ _ _ _ -> error "contracts not supported"
+  Create _ _ _ -> error "contracts not supported"
   -- polymorphic
   Eq _ _ a b -> binop "=" a b
   NEq p s a b -> unop "not" (Eq p s a b)

--- a/src/SMT.hs
+++ b/src/SMT.hs
@@ -590,6 +590,7 @@ expToSMT2 expr = case expr of
   IntMax _ a -> pure . show $ intmax a
   UIntMin _ a -> pure . show $ uintmin a
   UIntMax _ a -> pure . show $ uintmax a
+  InRange _ t e -> expToSMT2 (bound t e)
 
   -- bytestrings
   Cat _ a b -> binop "str.++" a b

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -382,6 +382,7 @@ getPosn expr = case expr of
     EnvExp pn _ -> pn
     IntLit pn _ -> pn
     BoolLit pn _ -> pn
+    EInRange pn _ _ -> pn
 
 posFromDef :: Defn -> Pn
 posFromDef (Defn e _) = getPosn e
@@ -423,6 +424,7 @@ idFromRewrites e = case e of
   EnvExp {}         -> empty
   IntLit {}         -> empty
   BoolLit {}        -> empty
+  EInRange _ _ a    -> idFromRewrites a
   where
     idFromRewrites' = unionsWith (<>) . fmap idFromRewrites
 

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -112,7 +112,7 @@ locsFromExp = nub . go
       LitBool {} -> []
       IntEnv {} -> []
       ByEnv {} -> []
-      Create _ _ _ es -> concatMap locsFromTypedExp es
+      Create _ _ es -> concatMap locsFromTypedExp es
       ITE _ x y z -> go x <> go y <> go z
       TEntry _ _ a -> locsFromItem a
       Var {} -> []
@@ -150,7 +150,7 @@ createsFromExp = nub . go
       LitBool {} -> []
       IntEnv {} -> []
       ByEnv {} -> []
-      Create _ _ f es -> [f] <> concatMap createsFromTypedExp es
+      Create _ f es -> [f] <> concatMap createsFromTypedExp es
       ITE _ x y z -> go x <> go y <> go z
       TEntry _ _ a -> createsFromItem a
       Var {} -> []
@@ -255,7 +255,7 @@ ethEnvFromExp = nub . go
       UIntMax {} -> []
       IntEnv _ a -> [a]
       ByEnv _ a -> [a]
-      Create _ _ _ ixs -> concatMap ethEnvFromTypedExp ixs
+      Create _ _ ixs -> concatMap ethEnvFromTypedExp ixs
       TEntry _ _ a -> ethEnvFromItem a
       Var {} -> []
 

--- a/src/Syntax/TimeAgnostic.hs
+++ b/src/Syntax/TimeAgnostic.hs
@@ -60,7 +60,9 @@ data Contract t = Contract (Constructor t) [Behaviour t]
 deriving instance Show (InvariantPred t) => Show (Contract t)
 deriving instance Eq   (InvariantPred t) => Eq   (Contract t)
 
-type Store = Map Id (Map Id SlotType)
+-- For each contract, it stores the type of a storage variables and
+-- the order in which they are declared
+type Store = Map Id (Map Id (SlotType, Integer))
 
 -- | Represents a contract level invariant along with some associated metadata.
 -- The invariant is defined in the context of the constructor, but must also be
@@ -377,7 +379,7 @@ instance ToJSON (Constructor Timed) where
                                   , "preConditions" .= toJSON _cpreconditions
                                   , "postConditions" .= toJSON _cpostconditions
                                   , "invariants" .= listValue (\i@Invariant{..} -> invariantJSON i _predicate) _invariants
-                                  , "storage" .= toJSON _initialStorage  ]
+                                  , "initial storage" .= toJSON _initialStorage  ]
 
 instance ToJSON (Constructor Untimed) where
   toJSON Constructor{..} = object [ "kind" .= String "Constructor"

--- a/src/Syntax/Untyped.hs
+++ b/src/Syntax/Untyped.hs
@@ -62,7 +62,7 @@ data Assign = AssignVal StorageVar Expr | AssignMany StorageVar [Defn] | AssignS
   deriving (Eq, Show)
 -- TODO AssignStruct is never used
 
-data IffH = Iff Pn [Expr] | IffIn Pn AbiType [Expr]
+data IffH = Iff Pn [Expr]
   deriving (Eq, Show)
 
 data Entry
@@ -108,6 +108,7 @@ data Expr
   | EnvExp Pn EthEnv
   | IntLit Pn Integer
   | BoolLit Pn Bool
+  | EInRange Pn AbiType Expr
   deriving (Eq, Show)
 
 data EthEnv

--- a/src/Syntax/Untyped.hs
+++ b/src/Syntax/Untyped.hs
@@ -167,3 +167,8 @@ instance ToJSON SlotType where
   toJSON (StorageMapping ixTypes valType) = object [ "type" .= String "mapping"
                                                    , "ixTypes" .= show (toList ixTypes)
                                                    , "valType" .= show valType]
+
+-- Create the string that is used to construct the function selector
+makeIface :: Interface -> String
+makeIface (Interface a decls) =
+ a <> "(" <> intercalate "," (fmap (\(Decl typ _) -> show typ) decls) <> ")"

--- a/src/Syntax/Untyped.hs
+++ b/src/Syntax/Untyped.hs
@@ -62,7 +62,7 @@ data Assign = AssignVal StorageVar Expr | AssignMany StorageVar [Defn] | AssignS
   deriving (Eq, Show)
 -- TODO AssignStruct is never used
 
-data IffH = Iff Pn [Expr]
+data IffH = Iff Pn [Expr] | IffIn Pn AbiType [Expr]
   deriving (Eq, Show)
 
 data Entry

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -176,7 +176,6 @@ defaultStore =
    (Origin, AInteger),
    (Nonce, AInteger),
    (Calldepth, AInteger)
-   --others TODO
   ]
 
 

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -397,12 +397,12 @@ genInRange t e@(Mul _ e1 e2) = [InRange nowhere t e] <> genInRange t e1 <> genIn
 genInRange t e@(Div _ e1 e2) = [InRange nowhere t e] <> genInRange t e1 <> genInRange t e2
 genInRange t e@(Mod _ e1 e2) = [InRange nowhere t e] <> genInRange t e1 <> genInRange t e2
 genInRange t e@(Exp _ e1 e2) = [InRange nowhere t e] <> genInRange t e1 <> genInRange t e2
-genInRange _ (IntMin _ _)  = error "Internal error: invalid in range expression"
-genInRange _ (IntMax _ _)  = error "Internal error: invalid in range expression"
-genInRange _ (UIntMin _ _) = error "Internal error: invalid in range expression"
-genInRange _ (UIntMax _ _) = error "Internal error: invalid in range expression"
-genInRange _ (ITE _ _ _ _) = error "Internal error: invalid in range expression"
-genInRange _ (IntEnv _ _) = error "Internal error: invalid in range expression"
+genInRange t e@(IntEnv _ _) = [InRange nowhere t e]
+genInRange _ (IntMin _ _)  = error "Internal error: invalid range expression"
+genInRange _ (IntMax _ _)  = error "Internal error: invalid range expression"
+genInRange _ (UIntMin _ _) = error "Internal error: invalid range expression"
+genInRange _ (UIntMax _ _) = error "Internal error: invalid range expression"
+genInRange _ (ITE _ _ _ _) = error "Internal error: invalid range expression"
 
 -- | Attempt to construct a `TypedExp` whose type matches the supplied `ValueType`.
 -- The target timing parameter will be whatever is required by the caller.

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -385,6 +385,7 @@ checkIffs :: Env -> [U.IffH] -> Err [Exp ABoolean Untimed]
 checkIffs env = foldr check (pure [])
   where
     check (U.Iff   _     exps) acc = mappend <$> traverse (checkExpr env SBoolean) exps <*> acc
+    check (U.IffIn _ typ exps) acc = mappend <$> (mconcat <$> traverse (fmap (genInRange typ) . checkExpr env SInteger) exps) <*> acc
 
 genInRange :: AbiType -> Exp AInteger t -> [Exp ABoolean t]
 genInRange t e@(LitInt _ _) = [InRange nowhere t e]

--- a/src/act.cabal
+++ b/src/act.cabal
@@ -69,3 +69,5 @@ Test-Suite test
                     tasty-quickcheck       >= 0.10,
                     QuickCheck             >= 2.13.2,
                     tasty                  >= 1.2
+  if os(darwin)
+      extra-libraries: c++

--- a/src/act.cabal
+++ b/src/act.cabal
@@ -15,10 +15,6 @@ common deps
                  aeson              >= 1.0,
                  containers         >= 0.5,
                  hevm               ,
-                 -- hevm version has an ugly upper bound to
-                 -- force usage of version from nix-shell,
-                 -- which avoids weird missing deps when
-                 -- pulling it from hackage.
                  lens               >= 4.17.1,
                  text               >= 1.2,
                  array              >= 0.5.3.0,
@@ -46,7 +42,7 @@ library
   hs-source-dirs:     .
   default-language:   Haskell2010
   exposed-modules:    CLI Error Print SMT Syntax.Annotated Syntax.TimeAgnostic
-  other-modules:      Lex Parse K Coq Syntax Syntax.Untyped Syntax.Typed Syntax.Types Syntax.Timing Type Enrich Dev
+  other-modules:      Lex Parse K Coq Syntax Syntax.Untyped Syntax.Typed Syntax.Types Syntax.Timing Type Enrich Dev HEVM
 
 executable act
   import:             deps

--- a/src/act.cabal
+++ b/src/act.cabal
@@ -30,7 +30,8 @@ common deps
                  ordered-containers >= 0.2.2,
                  extra,
                  singletons,
-                 deriving-compat
+                 deriving-compat,
+                 async              >= 2.2.4,
   if flag(ci)
       ghc-options: -O2 -Wall -Werror -Wno-orphans -Wno-unticked-promoted-constructors
   else

--- a/src/act.cabal
+++ b/src/act.cabal
@@ -52,6 +52,8 @@ executable act
   hs-source-dirs:     main
   default-language:   Haskell2010
   build-depends:      act
+  if os(darwin)
+      extra-libraries: c++
 
 Test-Suite test
   import:           deps

--- a/src/act.cabal
+++ b/src/act.cabal
@@ -32,6 +32,7 @@ common deps
                  singletons,
                  deriving-compat,
                  async              >= 2.2.4,
+                 data-dword         >= 0.3.2.1,
   if flag(ci)
       ghc-options: -O2 -Wall -Werror -Wno-orphans -Wno-unticked-promoted-constructors
   else

--- a/src/test/Test.hs
+++ b/src/test/Test.hs
@@ -29,6 +29,7 @@ import Syntax.Annotated
 import Text.Pretty.Simple
 import Data.Text.Lazy as T (unpack)
 
+import Debug.Trace
 
 -- Transformer stack to keep track of whether we are to generate expressions
 -- with exponentiation or not (for compatibility with SMT).

--- a/src/test/Test.hs
+++ b/src/test/Test.hs
@@ -26,9 +26,9 @@ import Print (prettyBehaviour)
 import SMT
 import Syntax.Annotated
 
-import Debug.Trace
 import Text.Pretty.Simple
 import Data.Text.Lazy as T (unpack)
+
 
 -- Transformer stack to keep track of whether we are to generate expressions
 -- with exponentiation or not (for compatibility with SMT).
@@ -72,7 +72,7 @@ defaultStore :: Id -> Store
 defaultStore c = fromList [(c,fromList [])]
 
 defaultCtor :: Id -> Constructor
-defaultCtor c = Constructor {_cname = c, _cinterface = Interface "constructor" [], _cpreconditions = [], _cpostconditions = [], _invariants = [], _initialStorage = [], _cstateUpdates = []}
+defaultCtor c = Constructor {_cname = c, _cinterface = Interface c [], _cpreconditions = [], _cpostconditions = [], _invariants = [], _initialStorage = [], _cstateUpdates = []}
 
 
 typeCheckSMT :: Solver -> GenT (Reader Bool) Property

--- a/tests/coq/safemath/Theory.v
+++ b/tests/coq/safemath/Theory.v
@@ -24,6 +24,8 @@ Proof.
     - assumption.
     - assumption.
     - assumption.
+    - assumption.
+    - assumption.
   } {
     intros. destruct H.
     split. assumption.

--- a/tests/frontend/pass/creation/create.act.typed.json
+++ b/tests/frontend/pass/creation/create.act.typed.json
@@ -4,7 +4,27 @@
       "behaviors": [],
       "constructor": {
         "contract": "Modest",
-        "interface": "constructor()",
+        "initial storage": [
+          {
+            "location": {
+              "item": {
+                "var": "Modest.x"
+              },
+              "sort": "int"
+            },
+            "value": "1"
+          },
+          {
+            "location": {
+              "item": {
+                "var": "Modest.y"
+              },
+              "sort": "int"
+            },
+            "value": "Caller"
+          }
+        ],
+        "interface": "Modest()",
         "invariants": [],
         "kind": "Constructor",
         "postConditions": [],
@@ -31,26 +51,6 @@
             "arity": 2,
             "symbol": "and"
           }
-        ],
-        "storage": [
-          {
-            "location": {
-              "item": {
-                "var": "Modest.x"
-              },
-              "sort": "int"
-            },
-            "value": "1"
-          },
-          {
-            "location": {
-              "item": {
-                "var": "Modest.y"
-              },
-              "sort": "int"
-            },
-            "value": "Caller"
-          }
         ]
       },
       "kind": "Contract"
@@ -61,12 +61,18 @@
     "kind": "Storages",
     "storages": {
       "Modest": {
-        "x": {
-          "type": "uint256"
-        },
-        "y": {
-          "type": "address"
-        }
+        "x": [
+          {
+            "type": "uint256"
+          },
+          0
+        ],
+        "y": [
+          {
+            "type": "address"
+          },
+          1
+        ]
       }
     }
   }

--- a/tests/frontend/pass/multi/multi.act.typed.json
+++ b/tests/frontend/pass/multi/multi.act.typed.json
@@ -4,12 +4,7 @@
       "behaviors": [],
       "constructor": {
         "contract": "A",
-        "interface": "constructor()",
-        "invariants": [],
-        "kind": "Constructor",
-        "postConditions": [],
-        "preConditions": [],
-        "storage": [
+        "initial storage": [
           {
             "location": {
               "item": {
@@ -19,7 +14,12 @@
             },
             "value": "0"
           }
-        ]
+        ],
+        "interface": "A()",
+        "invariants": [],
+        "kind": "Constructor",
+        "postConditions": [],
+        "preConditions": []
       },
       "kind": "Contract"
     },
@@ -341,12 +341,7 @@
       ],
       "constructor": {
         "contract": "B",
-        "interface": "constructor()",
-        "invariants": [],
-        "kind": "Constructor",
-        "postConditions": [],
-        "preConditions": [],
-        "storage": [
+        "initial storage": [
           {
             "location": {
               "item": {
@@ -374,7 +369,12 @@
               "symbol": "create"
             }
           }
-        ]
+        ],
+        "interface": "B()",
+        "invariants": [],
+        "kind": "Constructor",
+        "postConditions": [],
+        "preConditions": []
       },
       "kind": "Contract"
     }
@@ -384,17 +384,26 @@
     "kind": "Storages",
     "storages": {
       "A": {
-        "x": {
-          "type": "uint256"
-        }
+        "x": [
+          {
+            "type": "uint256"
+          },
+          0
+        ]
       },
       "B": {
-        "a": {
-          "type": "A"
-        },
-        "y": {
-          "type": "uint256"
-        }
+        "a": [
+          {
+            "type": "A"
+          },
+          1
+        ],
+        "y": [
+          {
+            "type": "uint256"
+          },
+          0
+        ]
       }
     }
   }

--- a/tests/frontend/pass/safemath/safemathraw.act.typed.json
+++ b/tests/frontend/pass/safemath/safemathraw.act.typed.json
@@ -14,37 +14,29 @@
               "args": [
                 {
                   "args": [
-                    "0",
-                    {
-                      "args": [
-                        "x",
-                        "y"
-                      ],
-                      "arity": 2,
-                      "symbol": "+"
-                    }
+                    "x",
+                    "y"
                   ],
                   "arity": 2,
-                  "symbol": "<="
-                },
-                {
-                  "args": [
-                    {
-                      "args": [
-                        "x",
-                        "y"
-                      ],
-                      "arity": 2,
-                      "symbol": "+"
-                    },
-                    "115792089237316195423570985008687907853269984665640564039457584007913129639935"
-                  ],
-                  "arity": 2,
-                  "symbol": "<="
+                  "symbol": "+"
                 }
               ],
-              "arity": 2,
-              "symbol": "and"
+              "arity": 1,
+              "symbol": "inrangeuint256"
+            },
+            {
+              "args": [
+                "x"
+              ],
+              "arity": 1,
+              "symbol": "inrangeuint256"
+            },
+            {
+              "args": [
+                "y"
+              ],
+              "arity": 1,
+              "symbol": "inrangeuint256"
             },
             {
               "args": [
@@ -137,12 +129,12 @@
       ],
       "constructor": {
         "contract": "SafeAdd",
-        "interface": "constructor()",
+        "initial storage": [],
+        "interface": "SafeAdd()",
         "invariants": [],
         "kind": "Constructor",
         "postConditions": [],
-        "preConditions": [],
-        "storage": []
+        "preConditions": []
       },
       "kind": "Contract"
     }

--- a/tests/frontend/pass/smoke/smoke.act.typed.json
+++ b/tests/frontend/pass/smoke/smoke.act.typed.json
@@ -42,12 +42,12 @@
       ],
       "constructor": {
         "contract": "A",
-        "interface": "constructor()",
+        "initial storage": [],
+        "interface": "A()",
         "invariants": [],
         "kind": "Constructor",
         "postConditions": [],
-        "preConditions": [],
-        "storage": []
+        "preConditions": []
       },
       "kind": "Contract"
     }

--- a/tests/frontend/pass/token/transfer.act.typed.json
+++ b/tests/frontend/pass/token/transfer.act.typed.json
@@ -3598,7 +3598,57 @@
       ],
       "constructor": {
         "contract": "Token",
-        "interface": "constructor(string _symbol, string _name, string _version, uint256 _totalSupply)",
+        "initial storage": [
+          {
+            "location": {
+              "item": {
+                "var": "Token.name"
+              },
+              "sort": "bytestring"
+            },
+            "value": "_name"
+          },
+          {
+            "location": {
+              "item": {
+                "var": "Token.symbol"
+              },
+              "sort": "bytestring"
+            },
+            "value": "_symbol"
+          },
+          {
+            "location": {
+              "item": {
+                "var": "Token.totalSupply"
+              },
+              "sort": "int"
+            },
+            "value": "_totalSupply"
+          },
+          {
+            "location": {
+              "item": {
+                "args": [
+                  {
+                    "var": "Token.balanceOf"
+                  },
+                  [
+                    {
+                      "expression": "Caller",
+                      "sort": "int"
+                    }
+                  ]
+                ],
+                "arity": 2,
+                "symbol": "lookup"
+              },
+              "sort": "int"
+            },
+            "value": "_totalSupply"
+          }
+        ],
+        "interface": "Token(string _symbol, string _name, string _version, uint256 _totalSupply)",
         "invariants": [
           {
             "contract": "Token",
@@ -3868,56 +3918,6 @@
             "arity": 2,
             "symbol": "and"
           }
-        ],
-        "storage": [
-          {
-            "location": {
-              "item": {
-                "var": "Token.name"
-              },
-              "sort": "bytestring"
-            },
-            "value": "_name"
-          },
-          {
-            "location": {
-              "item": {
-                "var": "Token.symbol"
-              },
-              "sort": "bytestring"
-            },
-            "value": "_symbol"
-          },
-          {
-            "location": {
-              "item": {
-                "var": "Token.totalSupply"
-              },
-              "sort": "int"
-            },
-            "value": "_totalSupply"
-          },
-          {
-            "location": {
-              "item": {
-                "args": [
-                  {
-                    "var": "Token.balanceOf"
-                  },
-                  [
-                    {
-                      "expression": "Caller",
-                      "sort": "int"
-                    }
-                  ]
-                ],
-                "arity": 2,
-                "symbol": "lookup"
-              },
-              "sort": "int"
-            },
-            "value": "_totalSupply"
-          }
         ]
       },
       "kind": "Contract"
@@ -3928,25 +3928,40 @@
     "kind": "Storages",
     "storages": {
       "Token": {
-        "allowance": {
-          "ixTypes": "[address,address]",
-          "type": "mapping",
-          "valType": "uint256"
-        },
-        "balanceOf": {
-          "ixTypes": "[address]",
-          "type": "mapping",
-          "valType": "uint256"
-        },
-        "name": {
-          "type": "string"
-        },
-        "symbol": {
-          "type": "string"
-        },
-        "totalSupply": {
-          "type": "uint256"
-        }
+        "allowance": [
+          {
+            "ixTypes": "[address,address]",
+            "type": "mapping",
+            "valType": "uint256"
+          },
+          4
+        ],
+        "balanceOf": [
+          {
+            "ixTypes": "[address]",
+            "type": "mapping",
+            "valType": "uint256"
+          },
+          3
+        ],
+        "name": [
+          {
+            "type": "string"
+          },
+          0
+        ],
+        "symbol": [
+          {
+            "type": "string"
+          },
+          1
+        ],
+        "totalSupply": [
+          {
+            "type": "uint256"
+          },
+          2
+        ]
       }
     }
   }

--- a/tests/hevm/pass/safemath/safemath.act
+++ b/tests/hevm/pass/safemath/safemath.act
@@ -23,3 +23,17 @@ iff
     CALLVALUE == 0
 
 returns x * y
+
+
+behaviour double of SafeAdd
+interface double(uint256 x)
+
+iff in range uint256
+
+    2 * x
+
+iff
+
+    CALLVALUE == 0
+
+returns 2 * x

--- a/tests/hevm/pass/safemath/safemath.act
+++ b/tests/hevm/pass/safemath/safemath.act
@@ -10,3 +10,16 @@ iff
     CALLVALUE == 0
 
 returns x + y
+
+behaviour mul of SafeAdd
+interface mul(uint256 x, uint256 y)
+
+iff in range uint256
+
+    x * y
+
+iff
+
+    CALLVALUE == 0
+
+returns x * y

--- a/tests/hevm/pass/safemath/safemath.sol
+++ b/tests/hevm/pass/safemath/safemath.sol
@@ -4,4 +4,8 @@ contract SafeAdd {
     function add(uint x, uint y) public pure returns (uint z) {
         require((z = x + y) >= x);
     }
+    
+    function mul(uint x, uint y) public pure returns (uint z) {
+        require((z = x * y) >= x);
+    }
 }

--- a/tests/hevm/pass/safemath/safemath.sol
+++ b/tests/hevm/pass/safemath/safemath.sol
@@ -8,4 +8,9 @@ contract SafeAdd {
     function mul(uint x, uint y) public pure returns (uint z) {
         require((z = x * y) >= x);
     }
+
+    function double(uint x) public pure returns (uint z) {
+	require((z = 2 * x) >= x);
+    }
+
 }

--- a/tests/hevm/pass/transfer-simple/transfer.act
+++ b/tests/hevm/pass/transfer-simple/transfer.act
@@ -1,0 +1,28 @@
+constructor of Token
+interface constructor(uint _totalSupply)
+
+creates
+  mapping(address => uint) balanceOf := [CALLER := _totalSupply]
+
+behaviour transfer of Token
+interface transfer(uint256 value, address to)
+
+
+iff
+
+  CALLVALUE == 0
+  CALLER =/= to => inRange(uint256, balanceOf[to] + value)
+  inRange(uint256,balanceOf[CALLER] - value)
+
+case CALLER =/= to:
+  
+  storage
+
+    balanceOf[CALLER]  => balanceOf[CALLER] - value
+    balanceOf[to]      => balanceOf[to] + value
+
+  returns 1
+
+  case CALLER == to:
+
+  returns 1

--- a/tests/hevm/pass/transfer-simple/transfer.sol
+++ b/tests/hevm/pass/transfer-simple/transfer.sol
@@ -1,0 +1,17 @@
+pragma solidity >=0.8.0;
+
+contract Token {
+    mapping (address => uint) public balanceOf;
+
+    constructor(uint _totalSupply) {
+        balanceOf[msg.sender] = _totalSupply;
+    }
+
+
+    function transfer(uint256 value, address to) public returns (uint) {
+	balanceOf[msg.sender] = balanceOf[msg.sender] - value;
+        balanceOf[to] = balanceOf[to] + value;
+        return 1;
+    }
+
+}


### PR DESCRIPTION
This PR implements a first prototype for checking equivalence between an Act spec and HEVM Expr obtained from EVM byte code. It works by translating Act to Expr and using the equivalence checker of HEVM to check equivalence. This is described in more detail in the [documentation](https://github.com/ethereum/act/blob/7f6e3b9a9d6a27bda5acee41d9d40f05ca55f31a/doc/src/equiv.md).

In more details the PR includes:

- The translation of Act to Expr (in [HEVM.hs](https://github.com/ethereum/act/blob/hevm-equiv/src/HEVM.hs)). 
- A top-level functionality that checks whether some Solidity code implements an Act spec (in [CLI.hs](https://github.com/ethereum/act/blob/hevm-equiv/src/CLI.hs)). 
- Implementation of the input space check (in [HEVM.hs](https://github.com/ethereum/act/blob/hevm-equiv/src/HEVM.hs))
- New syntax for in range assertions. When translating Act integers to machine words we need to implement integer bound differently. We add an `InRange` predicate to the typed AST that allows us to handle such bounds more modularly. We also need to be able to write conditional in-range assertions. So in the Act source instead of writing 
   ```
   iff in range uint256
     (a + b) + c
   iff 
     CALLVALUE == 0
   ```
  we now write 
   ```
   iff 
     CALLVALUE == 0
     inRange(uint256, (a + b) + c)
   ```
   In the typed AST, the in-range assertion gets elaborated to `InRange(a), InRange(b), InRange(c), InRange(a+b), InRange((a+b) +c)`, requiring that all intermediate expressions are within the given range and no overflow occurs. 
   
   Then, `InRange` predicates are translated according to the integer representation of each backend. 
   
- A new type for  `Store` that also keeps track of the order in which storage variables are declared. This is useful in order to provide a faithful storage layout when translating to Expr. 