### PR TITLE
ABI exhaustiveness check

### DIFF
--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -17,7 +17,6 @@ import System.Exit ( exitFailure )
 import System.IO (hPutStrLn, stderr, stdout)
 import Data.Text (pack, unpack)
 import Data.List
-import Data.Containers.ListUtils
 import Data.Maybe
 import Data.Traversable
 import qualified EVM.Solidity as Solidity
@@ -27,7 +26,6 @@ import qualified Data.Map.Strict as Map
 import Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 import GHC.Natural
 
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy.Char8 as B
 
 import Control.Monad
@@ -49,10 +47,7 @@ import HEVM
 import EVM.SymExec
 import qualified EVM.Solvers as Solvers
 import EVM.Solidity
-import qualified EVM.Format as Format
 import qualified EVM.Types as EVM
-import qualified EVM.Expr as EVM
-import qualified EVM.Fetch as Fetch
 
 --command line options
 data Command w
@@ -226,7 +221,7 @@ hevm actspec cid sol' solver' timeout _ = do
   sequence_ $ flip fmap actbehvs $ \(name,behvs,calldata) ->
     Solvers.withSolvers solver' 1 (naturalFromInteger <$> timeout) $ \solvers -> do
       solbehvs <- removeFails <$> getBranches solvers bytecode calldata
-      putStrLn $ "\x1b[1mChecking behavior \x1b[4m" <> name <> " of Act\x1b[m"
+      putStrLn $ "\x1b[1mChecking behavior \x1b[4m" <> name <> "\x1b[m of Act\x1b[m"
       -- equivalence check
       putStrLn "\x1b[1mChecking if behaviour is matched by EVM\x1b[m"
       checkResult =<< checkEquiv solvers debugVeriOpts solbehvs behvs

--- a/src/HEVM.hs
+++ b/src/HEVM.hs
@@ -389,7 +389,7 @@ checkOp (ITE _ _ _ _) = error "Internal error: invalid in range expression"
 checkOp (IntEnv _ _) = error "Internal error: invalid in range expression"
 
 
--- | Checks whether all successful EVM behaviors are withing the
+-- | Checks whether all successful EVM behaviors are within the
 -- interfaces specified by Act
 checkAbi :: SolverGroup -> VeriOpts -> Act -> BS.ByteString -> IO [EquivResult]
 checkAbi solver opts act bytecode = do

--- a/tests/hevm/pass/safemath/safemath.act
+++ b/tests/hevm/pass/safemath/safemath.act
@@ -6,7 +6,6 @@ iff in range uint256
     x + y
 
 iff
-
     CALLVALUE == 0
 
 returns x + y
@@ -23,7 +22,6 @@ iff
     CALLVALUE == 0
 
 returns x * y
-
 
 behaviour double of SafeAdd
 interface double(uint256 x)

--- a/tests/hevm/pass/safemath/safemath.sol
+++ b/tests/hevm/pass/safemath/safemath.sol
@@ -1,16 +1,16 @@
 pragma solidity >=0.4.21;
 
 contract SafeAdd {
-    function add(uint x, uint y) public pure returns (uint z) {
-        require((z = x + y) >= x);
-    }
-    
-    function mul(uint x, uint y) public pure returns (uint z) {
-        require((z = x * y) >= x);
+    function add(uint x, uint y) public pure returns (uint) {
+	return (x + y);
     }
 
-    function double(uint x) public pure returns (uint z) {
-	require((z = 2 * x) >= x);
+    function mul(uint x, uint y) public pure returns (uint) {
+	return (x * y);
+    }
+
+    function double(uint x) public pure returns (uint) {
+	return (2*x);
     }
 
 }

--- a/tests/hevm/pass/transfer-simple/transfer.act
+++ b/tests/hevm/pass/transfer-simple/transfer.act
@@ -4,9 +4,16 @@ interface constructor(uint _totalSupply)
 creates
   mapping(address => uint) balanceOf := [CALLER := _totalSupply]
 
+behaviour balanceOf of Token
+interface balanceOf(address x)
+
+iff CALLVALUE == 0
+
+returns
+  pre(balanceOf[x])
+
 behaviour transfer of Token
 interface transfer(uint256 value, address to)
-
 
 iff
 
@@ -23,6 +30,6 @@ case CALLER =/= to:
 
   returns 1
 
-  case CALLER == to:
+case CALLER == to:
 
   returns 1


### PR DESCRIPTION
This PR includes:

- New check that checks whether all reachable successes in Solidity are described by the Act spec. This is checked by asserting that the function selector is not equal to the selectors of the interfaces in Act, and trying to find reachable successes.

- Removal of the range assertions in the initial calldata.

- Some cleanup and moving functions from CLI to HEVM.

- Some pretty colors for the output of Act.
