### PR TITLE
hie.yaml small rename

### DIFF
--- a/src/hie.yaml
+++ b/src/hie.yaml
@@ -1,7 +1,7 @@
 cradle:
   cabal:
     - path: "."
-      component: "lib:act-internal"
+      component: "lib:act"
     - path: "./Main.hs"
       component: "exe:act"
     - path: "./test"


### PR DESCRIPTION
Im not sure what the HLS uses `hie.yaml` for, but I was getting this gignatic error from it that wouldnt let me use the LSP:
![image](https://github.com/ethereum/act/assets/39626597/8487ada0-7af8-4c26-8390-4df360c36c69)
So I just renamed `act-internal` to `act` in `hie.yaml` and now its working smooth. Dk if this might break any of your envs tho.