### PR TITLE
Add constant assertions to SMT encoding of postconditions

### DIFF
--- a/tests/postconditions/pass/amm.act
+++ b/tests/postconditions/pass/amm.act
@@ -1,0 +1,121 @@
+constructor of Token
+interface constructor(uint _supply)
+
+iff
+    CALLVALUE == 0
+
+creates
+    mapping(address => uint) balanceOf :=  [CALLER := _supply]
+
+behaviour balanceOf of Token
+interface balanceOf(address a)
+
+iff
+
+  CALLVALUE == 0
+
+returns pre(balanceOf[a])
+
+
+behaviour transferFrom of Token
+interface transferFrom(uint256 value, address from, address to)
+
+iff
+
+  CALLVALUE == 0
+  from =/= to => inRange(uint256, balanceOf[to] + value)
+  inRange(uint256,balanceOf[from] - value)
+
+case from =/= to:
+
+  storage
+
+    balanceOf[from]  => balanceOf[from] - value
+    balanceOf[to]    => balanceOf[to] + value
+
+  returns 1
+
+case from == to:
+
+  returns 1
+
+
+constructor of Amm
+interface constructor(uint256 amt1, uint256 amt2)
+
+iff
+
+    CALLVALUE == 0
+
+
+creates
+
+    Token token0 := create Token(amt1)
+    Token token1 := create Token(amt2)
+
+behaviour swap0 of Amm
+interface swap0(uint256 amt)
+
+iff
+    CALLVALUE == 0
+    inRange(uint256,token0.balanceOf[CALLER] - amt)
+    CALLER =/= THIS => inRange(uint256,token0.balanceOf[THIS] + amt)
+
+    inRange(uint256,token1.balanceOf[THIS] - ((token1.balanceOf[THIS] * amt) / (token0.balanceOf[THIS] + amt)))
+    CALLER =/= THIS => inRange(uint256,token1.balanceOf[CALLER] + ((token1.balanceOf[THIS] * amt) / (token0.balanceOf[THIS] + amt)))
+
+    token0.balanceOf[THIS] + amt =/= 0
+
+case CALLER =/= THIS:
+
+storage
+
+    token0.balanceOf[CALLER] => token0.balanceOf[CALLER] - amt
+    token0.balanceOf[THIS]   => token0.balanceOf[THIS] + amt
+
+    token1.balanceOf[THIS]   => token1.balanceOf[THIS] - ((token1.balanceOf[THIS] * amt) / (token0.balanceOf[THIS] + amt))
+    token1.balanceOf[CALLER] => token1.balanceOf[CALLER] + ((token1.balanceOf[THIS] * amt) / (token0.balanceOf[THIS] + amt))
+
+returns 1
+
+case CALLER == THIS:
+
+returns 1
+
+ensures
+
+    pre(token0.balanceOf[THIS]) * pre(token1.balanceOf[THIS]) <= post(token0.balanceOf[THIS]) * post(token1.balanceOf[THIS])
+
+
+behaviour swap1 of Amm
+interface swap1(uint256 amt)
+
+iff
+    CALLVALUE == 0
+    inRange(uint256,token1.balanceOf[CALLER] - amt)
+    CALLER =/= THIS => inRange(uint256,token1.balanceOf[THIS] + amt)
+
+    inRange(uint256,token0.balanceOf[THIS] - ((token0.balanceOf[THIS] * amt) / (token1.balanceOf[THIS] + amt)))
+    CALLER =/= THIS => inRange(uint256,token0.balanceOf[CALLER] + ((token0.balanceOf[THIS] * amt) / (token1.balanceOf[THIS] + amt)))
+
+    token1.balanceOf[THIS] + amt =/= 0
+
+case CALLER =/= THIS:
+
+storage
+
+    token1.balanceOf[CALLER] => token1.balanceOf[CALLER] - amt
+    token1.balanceOf[THIS]   => token1.balanceOf[THIS] + amt
+
+    token0.balanceOf[THIS]   => token0.balanceOf[THIS] - ((token0.balanceOf[THIS] * amt) / (token1.balanceOf[THIS] + amt))
+    token0.balanceOf[CALLER] => token0.balanceOf[CALLER] + ((token0.balanceOf[THIS] * amt) / (token1.balanceOf[THIS] + amt))
+
+returns 1
+
+case CALLER == THIS:
+
+returns 1
+
+ensures
+
+    pre(token0.balanceOf[THIS]) * pre(token1.balanceOf[THIS]) <= post(token0.balanceOf[THIS]) * post(token1.balanceOf[THIS])


### PR DESCRIPTION
This PR adds assertions that storage variables that are not explicitly modified remain constant. This was missing from the SMT encoding of postconditions.

Also, adds the AMΜ contract as a test in the postconditions directory that relies on these assertion to be proved.