### PR TITLE
Implement Solidity's memory layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ tests/hevm/fail/%.act.hevm.fail:
 
 tests/hevm/pass/%.act.hevm.pass.fast:
 	$(eval CONTRACT := $(shell awk '/contract/{ print $$2 }' tests/hevm/pass/$*.sol))
-	./bin/act hevm --spec tests/hevm/pass/$*.act --sol tests/hevm/pass/$*.sol --smttimeout 100000000
+	./bin/act hevm --spec tests/hevm/pass/$*.act --sol tests/hevm/pass/$*.sol --smttimeout 100000000 --solver z3
 
 test-ci: test-parse test-type test-invariant test-postcondition test-coq test-hevm
 test: test-ci test-cabal

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ tests/hevm/fail/%.act.hevm.fail:
 
 tests/hevm/pass/%.act.hevm.pass.fast:
 	$(eval CONTRACT := $(shell awk '/contract/{ print $$2 }' tests/hevm/pass/$*.sol))
-	./bin/act hevm --spec tests/hevm/pass/$*.act --sol tests/hevm/pass/$*.sol --smttimeout 100000000 --solver z3
+	./bin/act hevm --spec tests/hevm/pass/$*.act --sol tests/hevm/pass/$*.sol --smttimeout 100000000
 
 test-ci: test-parse test-type test-invariant test-postcondition test-coq test-hevm
 test: test-ci test-cabal

--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
         "solidity": "solidity"
       },
       "locked": {
-        "lastModified": 1742382723,
-        "narHash": "sha256-DWSfhKWX2tXoO3hxpguNxJh/DH3ScUc56pOFArXTEIE=",
+        "lastModified": 1743503242,
+        "narHash": "sha256-z+WWoVaQSmTuNICUIADuS0Skv8yO1QoerA3CO9C7Vz8=",
         "owner": "ethereum",
         "repo": "hevm",
-        "rev": "554ed54bec8fde232bc012c6bb0a031f30255fab",
+        "rev": "1637d3b0c492c4cf61969133cb6e8d8a88d2ca97",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -135,16 +135,15 @@
         "solidity": "solidity"
       },
       "locked": {
-        "lastModified": 1729608902,
-        "narHash": "sha256-6uTYwVYGGyVUdIcejP5shHdIzF/jp4XPz3kpDKN8FJ4=",
+        "lastModified": 1742382723,
+        "narHash": "sha256-DWSfhKWX2tXoO3hxpguNxJh/DH3ScUc56pOFArXTEIE=",
         "owner": "ethereum",
         "repo": "hevm",
-        "rev": "56d106e529162eda66253d4203dd4a39429317de",
+        "rev": "554ed54bec8fde232bc012c6bb0a031f30255fab",
         "type": "github"
       },
       "original": {
         "owner": "ethereum",
-        "ref": "dynamic-flake-output",
         "repo": "hevm",
         "type": "github"
       }
@@ -165,11 +164,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726481836,
-        "narHash": "sha256-MWTBH4dd5zIz2iatDb8IkqSjIeFum9jAqkFxgHLdzO4=",
+        "lastModified": 1742272065,
+        "narHash": "sha256-ud8vcSzJsZ/CK+r8/v0lyf4yUntVmDq6Z0A41ODfWbE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "20f9370d5f588fb8c72e844c54511cab054b5f40",
+        "rev": "3549532663732bfd89993204d40543e9edaec4f2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     hevm = {
-      url = "github:ethereum/hevm/dynamic-flake-output";
+      url = "github:ethereum/hevm";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
             pkgs.z3
             pkgs.cvc5
             pkgs.coq
+            pkgs.coqPackages.stdlib
             pkgs.solc
             pkgs.mdbook
             pkgs.mdbook-mermaid

--- a/lib/ActLib.v
+++ b/lib/ActLib.v
@@ -1,8 +1,7 @@
 (** library to be included with user coq developments *)
+From Stdlib Require Import ZArith.
 
-Require Import Coq.ZArith.ZArith.
-Open Scope Z_scope.
-
+Print LoadPath.
 (** * type definitions *)
 Definition address := Z.
 
@@ -24,13 +23,13 @@ Record Env : Set :=
 
 (** * integer bounds *)
 Definition UINT_MIN (n : Z) := 0.
-Definition UINT_MAX (n : Z) := 2^n - 1.
-Definition INT_MIN  (n : Z) := 0 - 2^(n - 1).
-Definition INT_MAX  (n : Z) := 2^(n - 1) - 1.
+Definition UINT_MAX (n : Z) := (2^n - 1)%Z.
+Definition INT_MIN  (n : Z) := (0 - 2^(n - 1))%Z.
+Definition INT_MAX  (n : Z) := (2^(n - 1) - 1)%Z.
 
 (** * notations *)
 Notation "a =?? b" := (bool_eq a b) (at level 70, no associativity).
-Definition range256 (n : Z) := 0 <= n <= UINT_MAX 256.
+Definition range256 (n : Z) := (0 <= n <= UINT_MAX 256)%Z.
 
 (** * lemmas *)
 

--- a/src/Act/Coq.hs
+++ b/src/Act/Coq.hs
@@ -167,7 +167,7 @@ baseRef :: Ref Storage -> StorageUpdate -> Bool
 baseRef baseref (Update _ (Item _ _ r) _) = hasBase r
   where
     hasBase (SVar _ _ _) = False
-    hasBase (SMapping _ r' _) = r' == baseref || hasBase r'
+    hasBase (SMapping _ r' _ _) = r' == baseref || hasBase r'
     hasBase (SField _ r' _ _) = r' == baseref || hasBase r'
 
 
@@ -357,7 +357,7 @@ entry (Item _ _ r) _ = ref r
 ref :: Ref k -> T.Text
 ref (SVar _ _ name) = parens $ T.pack name <> " " <> stateVar
 ref (CVar _ _ name) = T.pack name
-ref (SMapping _ r ixs) = parens $ ref r <> " " <> coqargs ixs
+ref (SMapping _ r _ ixs) = parens $ ref r <> " " <> coqargs ixs
 ref (SField _ r cid name) = parens $ T.pack cid <> "." <> T.pack name <> " " <> ref r
 
 -- | coq syntax for a list of arguments

--- a/src/Act/Decompile.hs
+++ b/src/Act/Decompile.hs
@@ -404,6 +404,13 @@ fromWord layout w = simplify <$> go w
         a' <- go a
         b' <- go b
         pure . evmbool $ InRange nowhere (AbiUIntType 256) (Mul nowhere a' b')
+    go (EVM.Or (EVM.Eq b (EVM.Div (EVM.Mod (EVM.Mul c d) (EVM.Lit MAX_UINT)) e)) (EVM.IsZero a))
+      | a == c
+      , a == e
+      , b == d = do
+        a' <- go a
+        b' <- go b
+        pure . evmbool $ InRange nowhere (AbiUIntType 256) (Mul nowhere a' b')
 
 
     -- SLT (max(a, length txdata) - 4) b == 0  if a - 4 = b
@@ -442,7 +449,6 @@ fromWord layout w = simplify <$> go w
              _ -> Left $ "unable to handle storage reads for variables of type: " <> T.pack (show tp)
 
     go e = err e
-
 
 -- Verification ------------------------------------------------------------------------------------
 

--- a/src/Act/Enrich.hs
+++ b/src/Act/Enrich.hs
@@ -96,5 +96,4 @@ mkStorageBoundsLoc refs = concatMap mkBound refs
 mkCallDataBounds :: [Decl] -> [Exp ABoolean]
 mkCallDataBounds = concatMap $ \(Decl typ name) -> case fromAbiType typ of
   AInteger -> [bound typ (_Var Pre typ name)]
-  ABoolean -> [bound typ (_Var Pre typ name)]
   _ -> []

--- a/src/Act/Enrich.hs
+++ b/src/Act/Enrich.hs
@@ -96,4 +96,5 @@ mkStorageBoundsLoc refs = concatMap mkBound refs
 mkCallDataBounds :: [Decl] -> [Exp ABoolean]
 mkCallDataBounds = concatMap $ \(Decl typ name) -> case fromAbiType typ of
   AInteger -> [bound typ (_Var Pre typ name)]
+  ABoolean -> [bound typ (_Var Pre typ name)]
   _ -> []

--- a/src/Act/HEVM.hs
+++ b/src/Act/HEVM.hs
@@ -253,7 +253,7 @@ applyUpdate readMap writeMap (Update typ (Item _ _ ref) e) = do
         fresh <- getFreshIncr
         let freshAddr = EVM.SymAddr $ "freshSymAddr" <> (T.pack $ show fresh)
         writeMap' <- localCaddr freshAddr $ createContract readMap writeMap freshAddr e
-        pure $ M.insert caddr' (updateNonce (updateStorage (EVM.SStore addr (EVM.WAddr freshAddr))contract), cid) writeMap'
+        pure $ M.insert caddr' (updateNonce (updateStorage (EVM.SStore addr (EVM.WAddr freshAddr)) contract), cid) writeMap'
       _ -> do
         e' <- toExpr readMap e
 
@@ -614,7 +614,7 @@ refToExp cmap r = do
   (slot, offset, size) <- refOffset cmap r
   let word = accessStorage cmap slot caddr
   let mask = (2 ^ (8 * size) - 1) `shiftL` (offset * 8)
-  pure $ EVM.Div (EVM.And word (EVM.Lit mask)) (EVM.Lit (2 ^(8 * size)))
+  pure $ EVM.Div (EVM.And word (EVM.Lit mask)) (EVM.Lit (2 ^ (8 * offset)))
 
 accessStorage :: ContractMap -> EVM.Expr EVM.EWord -> EVM.Expr EVM.EAddr -> EVM.Expr EVM.EWord
 accessStorage cmap slot addr = case M.lookup addr cmap of

--- a/src/Act/HEVM.hs
+++ b/src/Act/HEVM.hs
@@ -57,6 +57,8 @@ import EVM.Effects
 import EVM.Format as Format
 import EVM.Traversals
 
+import Debug.Trace
+
 type family ExprType a where
   ExprType 'AInteger  = EVM.EWord
   ExprType 'ABoolean  = EVM.EWord
@@ -305,6 +307,7 @@ createContract readMap writeMap freshAddr (Create _ cid args) = do
       applyUpdates (M.insert freshAddr (contract, cid) readMap) (M.insert freshAddr (contract, cid) writeMap) upds'
     Nothing -> error "Internal error: constructor not found"
 createContract _ _ _ _ = error "Internal error: constructor call expected"
+-- TODO needs to propagate up preconditions and check pointer constraints
 
 -- | Substitutions
 
@@ -771,6 +774,11 @@ checkConstructors solvers initcode runtimecode (Contract ctor@(Constructor _ ifa
   -- Symbolically execute bytecode
   -- TODO check if contrainsts about preexistsing fresh symbolic addresses are necessary
   solbehvs <- lift $ removeFails <$> getInitcodeBranches solvers initcode hevminitmap calldata (symAddrCnstr 1 fresh) fresh
+
+  traceM "Act"
+  traceM $ showBehvs actbehvs
+  traceM "Sol"
+  traceM $ showBehvs solbehvs
 
   -- Check equivalence
   lift $ showMsg "\x1b[1mChecking if constructor results are equivalent.\x1b[m"

--- a/src/Act/HEVM.hs
+++ b/src/Act/HEVM.hs
@@ -678,7 +678,7 @@ checkOp (Create _ _ _) = error "Internal error: invalid in range expression"
 -- | Wrapper for the equivalenceCheck function of hevm
 checkEquiv :: App m => SolverGroup -> [EVM.Expr EVM.End] -> [EVM.Expr EVM.End] -> m [EquivResult]
 checkEquiv solvers l1 l2 = do
-  res <- equivalenceCheck' solvers l1 l2
+  (res, _) <- equivalenceCheck' solvers l1 l2 False
   pure $ fmap toEquivRes res
   where
     toEquivRes :: SymExec.EquivResult -> EquivResult

--- a/src/Act/HEVM.hs
+++ b/src/Act/HEVM.hs
@@ -57,8 +57,6 @@ import EVM.Effects
 import EVM.Format as Format
 import EVM.Traversals
 
-import Debug.Trace
-
 type family ExprType a where
   ExprType 'AInteger  = EVM.EWord
   ExprType 'ABoolean  = EVM.EWord
@@ -199,7 +197,7 @@ translateConstructor bytecode (Constructor cid iface _ preconds _ _ upds) cmap =
 
 symAddrCnstr :: ContractMap -> [EVM.Prop]
 symAddrCnstr cmap =
-    (\(a1, a2) -> EVM.PNeg (EVM.PEq (EVM.WAddr a1) (EVM.WAddr a2))) <$> comb (M.keys cmap) 
+    (\(a1, a2) -> EVM.PNeg (EVM.PEq (EVM.WAddr a1) (EVM.WAddr a2))) <$> comb (M.keys cmap)
 
 translateBehvs :: Monad m => ContractMap -> [Behaviour] -> ActT m [(Id, [(EVM.Expr EVM.End, ContractMap)], Calldata, Sig)]
 translateBehvs cmap behvs = do
@@ -773,11 +771,6 @@ checkConstructors solvers initcode runtimecode (Contract ctor@(Constructor _ ifa
   -- TODO check if contrainsts about preexistsing fresh symbolic addresses are necessary
   solbehvs <- lift $ removeFails <$> getInitcodeBranches solvers initcode hevminitmap calldata [] fresh
 
---   traceM "Act"
---   traceM $ showBehvs actbehvs
---   traceM "Sol"
---   traceM $ showBehvs solbehvs
-
   -- Check equivalence
   lift $ showMsg "\x1b[1mChecking if constructor results are equivalent.\x1b[m"
   res1 <- lift $ checkResult calldata (Just sig) =<< checkEquiv solvers solbehvs actbehvs
@@ -797,14 +790,6 @@ checkBehaviours solvers (Contract _ behvs) actstorage = do
     let (behvs', fcmaps) = unzip actbehv
 
     solbehvs <- lift $ removeFails <$> getRuntimeBranches solvers hevmstorage calldata fresh
-
-
-    -- when (name == "upd") $ do
-    --   traceM "Act"
-    --   traceM $ showBehvs behvs'
-    --   traceM "Sol"
-    --   traceM $ showBehvs solbehvs
-
 
     lift $ showMsg $ "\x1b[1mChecking behavior \x1b[4m" <> name <> "\x1b[m of Act\x1b[m"
     -- equivalence check
@@ -1059,7 +1044,6 @@ toVRes msg res = case res of
 
 checkResult :: App m => Calldata -> Maybe Sig -> [EquivResult] -> m (Error String ())
 checkResult calldata sig res =
-  trace "Result: "$ traceShow res $
   case any isCex res of
     False ->
       case any isUnknown res || any isError res of

--- a/src/Act/HEVM.hs
+++ b/src/Act/HEVM.hs
@@ -58,8 +58,6 @@ import EVM.Effects
 import EVM.Format as Format
 import EVM.Traversals
 
-import Debug.Trace
-
 type family ExprType a where
   ExprType 'AInteger  = EVM.EWord
   ExprType 'ABoolean  = EVM.EWord
@@ -520,7 +518,7 @@ toProp cmap = \case
     pure $ EVM.PNeg e
   (NEq _ _ _ _) -> error "unsupported"
   (ITE _ _ _ _) -> error "Internal error: expecting flat expression"
-  (TEntry _ _ _ _) -> error "TODO" -- EVM.SLoad addr idx
+  (TEntry _ _ _ (Item SBoolean _ ref)) -> EVM.PEq (EVM.Lit 0) <$> EVM.IsZero <$> refToExp cmap ref
   (InRange _ t e) -> toProp cmap (inRange t e)
   where
     op2 :: Monad m => forall a b. (EVM.Expr (ExprType b) -> EVM.Expr (ExprType b) -> a) -> Exp b -> Exp b -> ActT m a
@@ -792,13 +790,6 @@ checkBehaviours solvers (Contract _ behvs) actstorage = do
     let (behvs', fcmaps) = unzip actbehv
 
     solbehvs <- lift $ removeFails <$> getRuntimeBranches solvers hevmstorage calldata fresh
-
-    
-    -- when (name == "setg") (do
-    --   traceM "Act behvs:"
-    --   traceM $ showBehvs behvs'
-    --   traceM "Sol behvs:"
-    --   traceM $ showBehvs solbehvs)
     
     lift $ showMsg $ "\x1b[1mChecking behavior \x1b[4m" <> name <> "\x1b[m of Act\x1b[m"
     -- equivalence check

--- a/src/Act/HEVM.hs
+++ b/src/Act/HEVM.hs
@@ -234,7 +234,7 @@ translateBehv cmap cdataprops (Behaviour _ _ _ _ preconds caseconds _ upds ret) 
   ret' <- returnsToExpr cmap ret
   cmap' <- applyUpdates cmap cmap upds
   let acmap = abstractCmap initAddr cmap'
-  pure (EVM.Success (preconds' <> caseconds' <> cdataprops <> symAddrCnstr acmap) mempty ret' (M.map fst cmap'), acmap)
+  pure (EVM.Success (preconds' <> caseconds' <> cdataprops <> symAddrCnstr cmap') mempty ret' (M.map fst cmap'), acmap)
 
 applyUpdates :: Monad m => ContractMap -> ContractMap -> [StorageUpdate] -> ActT m ContractMap
 applyUpdates readMap writeMap upds = foldM (applyUpdate readMap) writeMap upds
@@ -773,10 +773,10 @@ checkConstructors solvers initcode runtimecode (Contract ctor@(Constructor _ ifa
   -- TODO check if contrainsts about preexistsing fresh symbolic addresses are necessary
   solbehvs <- lift $ removeFails <$> getInitcodeBranches solvers initcode hevminitmap calldata [] fresh
 
-  traceM "Act"
-  traceM $ showBehvs actbehvs
-  traceM "Sol"
-  traceM $ showBehvs solbehvs
+--   traceM "Act"
+--   traceM $ showBehvs actbehvs
+--   traceM "Sol"
+--   traceM $ showBehvs solbehvs
 
   -- Check equivalence
   lift $ showMsg "\x1b[1mChecking if constructor results are equivalent.\x1b[m"
@@ -797,6 +797,14 @@ checkBehaviours solvers (Contract _ behvs) actstorage = do
     let (behvs', fcmaps) = unzip actbehv
 
     solbehvs <- lift $ removeFails <$> getRuntimeBranches solvers hevmstorage calldata fresh
+
+
+    -- when (name == "upd") $ do
+    --   traceM "Act"
+    --   traceM $ showBehvs behvs'
+    --   traceM "Sol"
+    --   traceM $ showBehvs solbehvs
+
 
     lift $ showMsg $ "\x1b[1mChecking behavior \x1b[4m" <> name <> "\x1b[m of Act\x1b[m"
     -- equivalence check

--- a/src/Act/HEVM_utils.hs
+++ b/src/Act/HEVM_utils.hs
@@ -49,12 +49,13 @@ defaultActConfig = Config
   , dumpExprs = False
   , dumpEndStates = False
   , debug = False
-  , abstRefineArith = False
-  , abstRefineMem   = False
   , dumpTrace = False
   , numCexFuzz = 0
   , onlyCexFuzz = False
   , decomposeStorage = False
+  , maxBranch = 100
+  , promiseNoReent = False
+  , maxBufSize = 64
   }
 
 debugActConfig :: Config

--- a/src/Act/HEVM_utils.hs
+++ b/src/Act/HEVM_utils.hs
@@ -56,6 +56,7 @@ defaultActConfig = Config
   , maxBranch = 100
   , promiseNoReent = False
   , maxBufSize = 64
+  , verb = 0
   }
 
 debugActConfig :: Config

--- a/src/Act/HEVM_utils.hs
+++ b/src/Act/HEVM_utils.hs
@@ -67,12 +67,12 @@ makeCalldata iface@(Interface _ decls) =
     mkArg (Decl typ x) = symAbiArg (T.pack x) typ
     makeSig = T.pack $ makeIface iface
     calldatas = fmap mkArg decls
-    (cdBuf, _) = combineFragments calldatas (EVM.ConcreteBuf "")
+    (cdBuf, props) = combineFragments calldatas (EVM.ConcreteBuf "")
     withSelector = writeSelector cdBuf makeSig
     sizeConstraints
       = (bufLength withSelector EVM..>= cdLen calldatas)
         EVM..&& (bufLength withSelector EVM..< (EVM.Lit (2 ^ (64 :: Integer))))
-  in (withSelector, [sizeConstraints])
+  in (withSelector, sizeConstraints:props)
 
 makeCtrCalldata :: Interface -> Calldata
 makeCtrCalldata (Interface _ decls) =

--- a/src/Act/Parse.y
+++ b/src/Act/Parse.y
@@ -230,14 +230,14 @@ StorageVar : SlotType id                              { StorageVar (posn $2) $1 
 
 AbiType : 'uint'
         { case validsize $1 of
-	     True  -> AbiUIntType $1
-	     False -> error $ "invalid uint size: uint" <> (show $1)
-	    }
+         True  -> AbiUIntType $1
+         False -> error $ "invalid uint size: uint" <> (show $1)
+        }
         | 'int'
         { case validsize $1 of
-	        True  -> AbiIntType $1
-	        False -> error $ "invalid int size: int" <> (show $1)
-	    }
+            True  -> AbiIntType $1
+            False -> error $ "invalid int size: int" <> (show $1)
+        }
        | 'bytes'                                      { AbiBytesType $1 }
        | AbiType '[' ilit ']'                         { AbiArrayType (fromIntegral $ value $3) $1 }
        | 'address'                                    { AbiAddressType }

--- a/src/Act/Parse.y
+++ b/src/Act/Parse.y
@@ -229,15 +229,15 @@ Decl : AbiType id                                     { Decl $1 (name $2) }
 StorageVar : SlotType id                              { StorageVar (posn $2) $1 (name $2) }
 
 AbiType : 'uint'
-         { case validsize $1 of
+        { case validsize $1 of
 	     True  -> AbiUIntType $1
 	     False -> error $ "invalid uint size: uint" <> (show $1)
-	 }
-       | 'int'
-         { case validsize $1 of
-	     True  -> AbiIntType $1
-	     False -> error $ "invalid int size: int" <> (show $1)
-	 }
+	    }
+        | 'int'
+        { case validsize $1 of
+	        True  -> AbiIntType $1
+	        False -> error $ "invalid int size: int" <> (show $1)
+	    }
        | 'bytes'                                      { AbiBytesType $1 }
        | AbiType '[' ilit ']'                         { AbiArrayType (fromIntegral $ value $3) $1 }
        | 'address'                                    { AbiAddressType }

--- a/src/Act/Print.hs
+++ b/src/Act/Print.hs
@@ -156,7 +156,7 @@ prettyRef :: Ref k t -> String
 prettyRef = \case
   CVar _ _ n -> n
   SVar _ _ n -> n
-  SMapping _ r args -> prettyRef r <> concatMap (brackets . prettyTypedExp) args
+  SMapping _ r _ args -> prettyRef r <> concatMap (brackets . prettyTypedExp) args
   SField _ r _ n -> prettyRef r <> "." <> n
   where
     brackets str = "[" <> str <> "]"
@@ -199,7 +199,7 @@ prettyInvPred = prettyExp . untime . fst
     untimeRef:: Ref k t -> Ref k Untimed
     untimeRef (SVar p c a) = SVar p c a
     untimeRef (CVar p c a) = CVar p c a
-    untimeRef (SMapping p e xs) = SMapping p (untimeRef e) (fmap untimeTyped xs)
+    untimeRef (SMapping p e ts xs) = SMapping p (untimeRef e) ts (fmap untimeTyped xs)
     untimeRef (SField p e c x) = SField p (untimeRef e) c x
 
     untime :: Exp a t -> Exp a Untimed

--- a/src/Act/SMT.hs
+++ b/src/Act/SMT.hs
@@ -552,7 +552,7 @@ declareStorage :: [When] -> StorageLocation -> [SMT2]
 declareStorage times (Loc _ item@(Item _ _ ref)) = declareRef ref
   where
     declareRef (SVar _ _ _) = (\t -> constant (nameFromSItem t item) (itemType item) ) <$> times
-    declareRef (SMapping _ _ ixs) = (\t -> array (nameFromSItem t item) ixs (itemType item)) <$> times
+    declareRef (SMapping _ _ _ ixs) = (\t -> array (nameFromSItem t item) ixs (itemType item)) <$> times
     declareRef (SField _ ref' _ _) = declareRef ref'
 
 
@@ -693,20 +693,20 @@ nameFromSItem whn (Item _ _ ref) = nameFromSRef ref @@ show whn
 
 nameFromSRef :: Ref Storage -> Id
 nameFromSRef (SVar _ c name) = c @@ name
-nameFromSRef (SMapping _ e _) = nameFromSRef e
+nameFromSRef (SMapping _ e _ _) = nameFromSRef e
 nameFromSRef (SField _ ref c x) = nameFromSRef ref @@ c @@ x
 
 nameFromItem :: When -> TItem k a -> Ctx Id
 nameFromItem whn (Item _ _ ref) = do
   name <- nameFromRef ref
   case ref of -- TODO: this feels rather adhoc, but I can't find a better way to handle timings
-    CVar _ _ _ -> pure $ name
+    CVar _ _ _ -> pure name
     _ -> pure $ name @@ show whn
 
 nameFromRef :: Ref k -> Ctx Id
 nameFromRef (CVar _ _ name) = nameFromVarId name
 nameFromRef (SVar _ c name) = pure $ c @@ name
-nameFromRef (SMapping _ e _) = nameFromRef e
+nameFromRef (SMapping _ e _ _) = nameFromRef e
 nameFromRef (SField _ ref c x) = do 
   name <- nameFromRef ref
   pure $ name @@ c @@ x

--- a/src/Act/Syntax.hs
+++ b/src/Act/Syntax.hs
@@ -272,7 +272,7 @@ idFromItem (Item _ _ ref) = idFromRef ref
 idFromRef :: Ref k t -> Id
 idFromRef (SVar _ _ x) = x
 idFromRef (CVar _ _ x) = x
-idFromRef (SMapping _ e _) = idFromRef e
+idFromRef (SMapping _ e _ _) = idFromRef e
 idFromRef (SField _ e _ _) = idFromRef e
 
 idFromUpdate :: StorageUpdate t -> Id
@@ -287,7 +287,7 @@ ixsFromItem (Item _ _ item) = ixsFromRef item
 ixsFromRef :: Ref k t -> [TypedExp t]
 ixsFromRef (SVar _ _ _) = []
 ixsFromRef (CVar _ _ _) = []
-ixsFromRef (SMapping _ ref ixs) = ixs ++ ixsFromRef ref
+ixsFromRef (SMapping _ ref _ ixs) = ixs ++ ixsFromRef ref
 ixsFromRef (SField _ ref _ _) = ixsFromRef ref
 
 ixsFromLocation :: StorageLocation t -> [TypedExp t]

--- a/src/Act/Syntax.hs
+++ b/src/Act/Syntax.hs
@@ -18,7 +18,6 @@ import qualified Act.Syntax.Annotated as Annotated
 import qualified Act.Syntax.Typed as Typed
 import           Act.Syntax.Untyped hiding (Contract)
 import qualified Act.Syntax.Untyped as Untyped
-import EVM.ABI (AbiValue(AbiBool))
 
 -----------------------------------------
 -- * Extract from fully refined ASTs * --

--- a/src/Act/Syntax.hs
+++ b/src/Act/Syntax.hs
@@ -469,5 +469,4 @@ upperBound (AbiUIntType  n) = UIntMax nowhere n
 upperBound (AbiIntType   n) = IntMax nowhere n
 upperBound AbiAddressType   = UIntMax nowhere 160
 upperBound (AbiBytesType n) = UIntMax nowhere (8 * n)
-upperBound AbiBoolType = LitInt nowhere 1
 upperBound typ = error $ "upperBound not implemented for " ++ show typ

--- a/src/Act/Syntax.hs
+++ b/src/Act/Syntax.hs
@@ -18,6 +18,7 @@ import qualified Act.Syntax.Annotated as Annotated
 import qualified Act.Syntax.Typed as Typed
 import           Act.Syntax.Untyped hiding (Contract)
 import qualified Act.Syntax.Untyped as Untyped
+import EVM.ABI (AbiValue(AbiBool))
 
 -----------------------------------------
 -- * Extract from fully refined ASTs * --
@@ -468,4 +469,5 @@ upperBound (AbiUIntType  n) = UIntMax nowhere n
 upperBound (AbiIntType   n) = IntMax nowhere n
 upperBound AbiAddressType   = UIntMax nowhere 160
 upperBound (AbiBytesType n) = UIntMax nowhere (8 * n)
+upperBound AbiBoolType = LitInt nowhere 1
 upperBound typ = error $ "upperBound not implemented for " ++ show typ

--- a/src/Act/Syntax/TimeAgnostic.hs
+++ b/src/Act/Syntax/TimeAgnostic.hs
@@ -181,7 +181,7 @@ eqKind fa fb = maybe False (\Refl -> fa == fb) $ testEquality (sing @a) (sing @b
 data Ref (k :: RefKind) (t :: Timing) where
   CVar :: Pn -> AbiType -> Id -> Ref Calldata t     -- Calldata variable
   SVar :: Pn -> Id -> Id -> Ref Storage t           -- Storage variable. First Id is the contract the var belogs to
-  SMapping :: Pn -> Ref k t -> [ValueType] -> [TypedExp t] -> Ref k t
+  SMapping :: Pn -> Ref k t -> ValueType -> [TypedExp t] -> Ref k t
   SField :: Pn -> Ref k t -> Id -> Id -> Ref k t    -- first Id is the contract the field belogs to
 deriving instance Show (Ref k t)
 

--- a/src/Act/Syntax/TimeAgnostic.hs
+++ b/src/Act/Syntax/TimeAgnostic.hs
@@ -181,16 +181,16 @@ eqKind fa fb = maybe False (\Refl -> fa == fb) $ testEquality (sing @a) (sing @b
 data Ref (k :: RefKind) (t :: Timing) where
   CVar :: Pn -> AbiType -> Id -> Ref Calldata t     -- Calldata variable
   SVar :: Pn -> Id -> Id -> Ref Storage t           -- Storage variable. First Id is the contract the var belogs to
-  SMapping :: Pn -> Ref k t -> [TypedExp t] -> Ref k t
+  SMapping :: Pn -> Ref k t -> [ValueType] -> [TypedExp t] -> Ref k t
   SField :: Pn -> Ref k t -> Id -> Id -> Ref k t    -- first Id is the contract the field belogs to
 deriving instance Show (Ref k t)
 
 instance Eq (Ref k t) where
-  CVar _ at x      == CVar _ at' x'      = at == at' && x == x'
-  SVar _ c x       == SVar _ c' x'       = c == c' && x == x'
-  SMapping _ r ixs == SMapping _ r' ixs' = r == r' && ixs == ixs'
-  SField _ r c x   == SField _ r' c' x'  = r == r' && c == c' && x == x'
-  _                == _                  = False
+  CVar _ at x         == CVar _ at' x'          = at == at' && x == x'
+  SVar _ c x          == SVar _ c' x'           = c == c' && x == x'
+  SMapping _ r ts ixs == SMapping _ r' ts' ixs' = r == r' && ts == ts' && ixs == ixs'
+  SField _ r c x      == SField _ r' c' x'      = r == r' && c == c' && x == x'
+  _                   == _                      = False
 
 -- | Item is a reference together with its Act type. The type is
 -- parametrized on a timing `t`, a type `a`, and the reference kind
@@ -373,7 +373,7 @@ instance Timable (TItem a k) where
    setTime time (Item t vt ref) = Item t vt $ setTime time ref
 
 instance Timable (Ref k) where
-  setTime time (SMapping p e ixs) = SMapping p (setTime time e) (setTime time <$> ixs)
+  setTime time (SMapping p e ts ixs) = SMapping p (setTime time e) ts (setTime time <$> ixs)
   setTime time (SField p e c x) = SField p (setTime time e) c x
   setTime _ (SVar p c x) = SVar p c x
   setTime _ (CVar p c x) = CVar p c x
@@ -483,9 +483,9 @@ instance ToJSON (Ref k t) where
                                , "svar" .=  pack x
                                , "contract" .= pack c ]
   toJSON (CVar _ at x) = object [ "kind" .= pack "Var"
-                                  , "var" .=  pack x
-                                  , "abitype" .=  toJSON at ]                                  
-  toJSON (SMapping _ e xs) = mapping e xs
+                                , "var" .=  pack x
+                                , "abitype" .=  toJSON at ]                                  
+  toJSON (SMapping _ e _ xs) = mapping e xs
   toJSON (SField _ e c x) = field e c x
 
 

--- a/src/Act/Traversals.hs
+++ b/src/Act/Traversals.hs
@@ -155,10 +155,10 @@ mapRefM :: Monad m => (forall a . Exp a t -> m (Exp a t)) -> Ref k t -> m (Ref k
 mapRefM f = \case
   SVar p a b -> pure (SVar p a b)
   CVar p a b -> pure (CVar p a b)
-  SMapping p a b -> do
+  SMapping p a ts b -> do
     a' <- mapRefM f a
     b' <- mapM (mapTypedExpM f) b
-    pure $ SMapping p a' b'
+    pure $ SMapping p a' ts b'
   SField p r a b -> do
     r' <- mapRefM f r
     pure $ SField p r' a b

--- a/src/Act/Type.hs
+++ b/src/Act/Type.hs
@@ -339,7 +339,7 @@ checkAssign _ _ = error "todo: support struct assignment in constructors"
 checkDefn :: Pn -> Env -> ValueType -> ValueType -> Id -> U.Defn -> Err StorageUpdate
 checkDefn pn env@Env{contract} keyType vt@(FromVType valType) name (U.Defn k val) =
   _Update
-  <$> (_Item vt . SMapping nowhere (SVar pn contract name) [keyType] <$> checkIxs env (getPosn k) [k] [keyType])
+  <$> (_Item vt . SMapping nowhere (SVar pn contract name) vt <$> checkIxs env (getPosn k) [k] [keyType])
   <*> checkExpr env valType val
 
 -- | Typechecks a postcondition, returning typed versions of its storage updates and return expression.
@@ -372,7 +372,7 @@ checkEntry env kind (U.EMapping p e args) =
   checkEntry env kind e `bindValidation` \(typ, _, ref) -> case typ of
     StorageValue _ -> throw (p, "Expression should have a mapping type" <> show e)
     StorageMapping argtyps restyp -> 
-        (StorageValue restyp, Nothing,) . SMapping p ref (NonEmpty.toList argtyps) <$> checkIxs env p args (NonEmpty.toList argtyps)
+        (StorageValue restyp, Nothing,) . SMapping p ref restyp <$> checkIxs env p args (NonEmpty.toList argtyps)
 checkEntry env@Env{theirs} kind (U.EField p e x) =
   checkEntry env kind e `bindValidation` \(_, oc, ref) -> case oc of
     Just c -> case Map.lookup c theirs of

--- a/src/Act/Type.hs
+++ b/src/Act/Type.hs
@@ -339,7 +339,7 @@ checkAssign _ _ = error "todo: support struct assignment in constructors"
 checkDefn :: Pn -> Env -> ValueType -> ValueType -> Id -> U.Defn -> Err StorageUpdate
 checkDefn pn env@Env{contract} keyType vt@(FromVType valType) name (U.Defn k val) =
   _Update
-  <$> (_Item vt . SMapping nowhere (SVar pn contract name) <$> checkIxs env (getPosn k) [k] [keyType])
+  <$> (_Item vt . SMapping nowhere (SVar pn contract name) [keyType] <$> checkIxs env (getPosn k) [k] [keyType])
   <*> checkExpr env valType val
 
 -- | Typechecks a postcondition, returning typed versions of its storage updates and return expression.
@@ -371,7 +371,8 @@ checkEntry Env{contract,store,calldata, pointers} kind (U.EVar p name) = case (k
 checkEntry env kind (U.EMapping p e args) =
   checkEntry env kind e `bindValidation` \(typ, _, ref) -> case typ of
     StorageValue _ -> throw (p, "Expression should have a mapping type" <> show e)
-    StorageMapping argtyps restyp -> (StorageValue restyp, Nothing,) . SMapping p ref <$> checkIxs env p args (NonEmpty.toList argtyps)
+    StorageMapping argtyps restyp -> 
+        (StorageValue restyp, Nothing,) . SMapping p ref (NonEmpty.toList argtyps) <$> checkIxs env p args (NonEmpty.toList argtyps)
 checkEntry env@Env{theirs} kind (U.EField p e x) =
   checkEntry env kind e `bindValidation` \(_, oc, ref) -> case oc of
     Just c -> case Map.lookup c theirs of

--- a/tests/hevm/pass/amm/amm.act
+++ b/tests/hevm/pass/amm/amm.act
@@ -41,17 +41,21 @@ case from == to:
 
 
 constructor of Amm
-interface constructor(uint256 amt1, uint256 amt2)
+interface constructor(address t0, address t1)
+
+pointers
+   t0 |-> Token
+   t1 |-> Token
 
 iff
 
     CALLVALUE == 0
-
+    t0 =/= t1
 
 creates
 
-    Token token0 := create Token(amt1)
-    Token token1 := create Token(amt2)
+    Token token0 := t0 
+    Token token1 := t1
 
 behaviour swap0 of Amm
 interface swap0(uint256 amt)
@@ -86,7 +90,6 @@ ensures
 
     pre(token0.balanceOf[THIS]) * pre(token1.balanceOf[THIS]) <= post(token0.balanceOf[THIS]) * post(token1.balanceOf[THIS])
     post(token0.balanceOf[THIS]) * post(token1.balanceOf[THIS]) <= pre(token0.balanceOf[THIS]) * pre(token1.balanceOf[THIS]) + pre(token0.balanceOf[THIS]) + amt
-
 
 
 behaviour swap1 of Amm

--- a/tests/hevm/pass/amm/amm.sol
+++ b/tests/hevm/pass/amm/amm.sol
@@ -9,7 +9,7 @@ contract Token {
 
 
     function transferFrom(uint256 value, address from, address to) public returns (uint) {
-	balanceOf[from] = balanceOf[from] - value;
+        balanceOf[from] = balanceOf[from] - value;
         balanceOf[to] = balanceOf[to] + value;
         return 1;
     }
@@ -22,29 +22,30 @@ contract Amm {
     Token token0;
     Token token1;
 
-    constructor(uint256 amt1, uint256 amt2) {
-        token0 = new Token(amt1);
-	token1 = new Token(amt2);
+    constructor(address t0, address t1) {
+        require (t0 != t1);
+        token0 = Token(t0);
+        token1 = Token(t1);
     }
 
     function swap0(uint256 amt) public returns (uint) {
-	uint256 reserve0 = token0.balanceOf(address(this));
-	uint256 reserve1 = token1.balanceOf(address(this));
+        uint256 reserve0 = token0.balanceOf(address(this));
+        uint256 reserve1 = token1.balanceOf(address(this));
 
-	token0.transferFrom(amt, msg.sender, address(this));
-	token1.transferFrom((reserve1*amt)/(reserve0+amt), address(this), msg.sender);
+        token0.transferFrom(amt, msg.sender, address(this));
+        token1.transferFrom((reserve1*amt)/(reserve0+amt), address(this), msg.sender);
 
-	return 1;
+        return 1;
     }
 
     function swap1(uint256 amt) public returns (uint) {
-	uint256 reserve0 = token0.balanceOf(address(this));
-	uint256 reserve1 = token1.balanceOf(address(this));
+        uint256 reserve0 = token0.balanceOf(address(this));
+        uint256 reserve1 = token1.balanceOf(address(this));
 
-	token1.transferFrom(amt, msg.sender, address(this));
-	token0.transferFrom((reserve0*amt)/(reserve1+amt), address(this), msg.sender);
+        token1.transferFrom(amt, msg.sender, address(this));
+        token0.transferFrom((reserve0*amt)/(reserve1+amt), address(this), msg.sender);
 
-	return 1;
+        return 1;
     }
 
 }

--- a/tests/hevm/pass/cast-3/cast-3.sol
+++ b/tests/hevm/pass/cast-3/cast-3.sol
@@ -10,7 +10,7 @@ contract Token {
 
 
     function transfer(address to, uint256 value) public returns (uint) {
-         balanceOf[msg.sender] = balanceOf[msg.sender] - value;
+        balanceOf[msg.sender] = balanceOf[msg.sender] - value;
         balanceOf[to] = balanceOf[to] + value;
         return 1;
     }
@@ -31,6 +31,6 @@ contract TransferOneToken {
         // Transfer 1 token from the contract to the sender
         uint256 transferAmt = 1;
         token.transfer(msg.sender, transferAmt);
-    return 1;
+        return 1;
     }
 }

--- a/tests/hevm/pass/cast-3/cast-3.sol
+++ b/tests/hevm/pass/cast-3/cast-3.sol
@@ -10,7 +10,7 @@ contract Token {
 
 
     function transfer(address to, uint256 value) public returns (uint) {
-	balanceOf[msg.sender] = balanceOf[msg.sender] - value;
+         balanceOf[msg.sender] = balanceOf[msg.sender] - value;
         balanceOf[to] = balanceOf[to] + value;
         return 1;
     }
@@ -31,6 +31,6 @@ contract TransferOneToken {
         // Transfer 1 token from the contract to the sender
         uint256 transferAmt = 1;
         token.transfer(msg.sender, transferAmt);
-	return 1;
+    return 1;
     }
 }

--- a/tests/hevm/pass/cast-4/cast-4.sol
+++ b/tests/hevm/pass/cast-4/cast-4.sol
@@ -4,7 +4,7 @@ contract C {
     uint z;
 
     constructor(uint z1) {
-	z = z1;
+        z = z1;
     }
 
 }
@@ -15,8 +15,8 @@ contract A {
     C c;
     
     constructor(uint x1) {
-	x = x1;
-	c = new C(42);
+        x = x1;
+        c = new C(42);
     }
 }
 
@@ -26,13 +26,13 @@ contract B {
     A a2;
 
     constructor(address x, address y) {
-	require (x != y);
-	a1 = A(x);
-	a2 = A(y);
+        require (x != y);
+        a1 = A(x);
+        a2 = A(y);
     }
 
     function upd() public {
-	a1 = new A(42);
-	a2 = new A(43);
+        a1 = new A(42);
+        a2 = new A(43);
     }
 }

--- a/tests/hevm/pass/cast-5/cast-5.sol
+++ b/tests/hevm/pass/cast-5/cast-5.sol
@@ -4,7 +4,7 @@ contract A {
     uint z;
 
     constructor(uint z1) {
-	z = z1;
+        z = z1;
     }
 
 }
@@ -13,7 +13,7 @@ contract B {
     uint t;
 
     constructor(uint t1) {
-	t = t1;
+        t = t1;
     }
 }
 
@@ -22,15 +22,15 @@ contract C {
     B b;
 
     constructor(address x, address y) {
-	a = A(x);
-	b = B(y);	
+        a = A(x);
+        b = B(y);
     }
 }
 
 contract D {
     C c2;
-    
+
     constructor(address x, address y) {
-	c2 = new C(x,y);	
+        c2 = new C(x,y);
     }
 }

--- a/tests/hevm/pass/cast-6/cast-6.sol
+++ b/tests/hevm/pass/cast-6/cast-6.sol
@@ -4,7 +4,7 @@ contract C {
     uint z;
 
     constructor(uint z1) {
-	z = z1;
+        z = z1;
     }
 
 }
@@ -15,8 +15,8 @@ contract A {
     C public c;
     
     constructor(uint x1) {
-	x = x1;
-	c = new C(42);
+        x = x1;
+        c = new C(42);
     }
 }
 
@@ -26,7 +26,7 @@ contract B {
     C c;
 
     constructor(address x) {
-	a = A(x);
-	c = a.c();
+        a = A(x);
+        c = a.c();
     }
 }

--- a/tests/hevm/pass/cast/cast.sol
+++ b/tests/hevm/pass/cast/cast.sol
@@ -4,16 +4,16 @@ contract A {
     uint x;
 
     constructor(uint _x) {
-	x = _x;
+        x = _x;
     }
 
 
     function getx() public returns (uint) {
-	return x;
+        return x;
     }
 
     function setx(uint _x1) public {
-	x = _x1;
+        x = _x1;
     }
 
 }
@@ -24,15 +24,15 @@ contract B {
     A a2;
 
     constructor(address x, address y) {
-	    require(x!=y);
-	    a1 = A(x);
-	    a2 = A(y);
+        require(x!=y);
+        a1 = A(x);
+        a2 = A(y);
     }
 
 
     function upd() public {
-	    a1.setx(42);
-	    a2.setx(11);
+        a1.setx(42);
+        a2.setx(11);
     }
 
 }

--- a/tests/hevm/pass/cast/cast.sol
+++ b/tests/hevm/pass/cast/cast.sol
@@ -24,15 +24,15 @@ contract B {
     A a2;
 
     constructor(address x, address y) {
-	require(x!=y);
-	a1 = A(x);
-	a2 = A(y);
+	    require(x!=y);
+	    a1 = A(x);
+	    a2 = A(y);
     }
 
 
     function upd() public {
-	a1.setx(42);
-	a2.setx(11);
+	    a1.setx(42);
+	    a2.setx(11);
     }
 
 }

--- a/tests/hevm/pass/layout1/layout1.act
+++ b/tests/hevm/pass/layout1/layout1.act
@@ -19,7 +19,6 @@ iff
 
   storage
 
-    x => 11
-    y => 42
+    x => y
 
   returns 1

--- a/tests/hevm/pass/layout1/layout1.act
+++ b/tests/hevm/pass/layout1/layout1.act
@@ -1,0 +1,25 @@
+constructor of A
+interface constructor()
+
+iff
+
+  CALLVALUE == 0
+
+creates
+
+  uint128 x := 11
+  uint128 y := 42
+
+behaviour swap of A
+interface swap()
+
+iff
+
+  CALLVALUE == 0
+
+  storage
+
+    x => y
+    y => x
+
+  returns 1

--- a/tests/hevm/pass/layout1/layout1.act
+++ b/tests/hevm/pass/layout1/layout1.act
@@ -7,8 +7,8 @@ iff
 
 creates
 
-  uint128 x := 0
-  uint128 y := 0
+  uint128 x := 11
+  uint128 y := 42
 
 behaviour swap of A
 interface swap()
@@ -20,5 +20,6 @@ iff
   storage
 
     x => y
+    y => x
 
   returns 1

--- a/tests/hevm/pass/layout1/layout1.act
+++ b/tests/hevm/pass/layout1/layout1.act
@@ -7,8 +7,8 @@ iff
 
 creates
 
-  uint128 x := 11
-  uint128 y := 42
+  uint128 x := 0
+  uint128 y := 0
 
 behaviour swap of A
 interface swap()
@@ -19,7 +19,7 @@ iff
 
   storage
 
-    x => y
-    y => x
+    x => 11
+    y => 42
 
   returns 1

--- a/tests/hevm/pass/layout1/layout1.sol
+++ b/tests/hevm/pass/layout1/layout1.sol
@@ -9,8 +9,8 @@ contract A {
 
     function swap() external returns (uint) {
 
-        x = 11;
-        y = 42;
+        x = y;
+        // y = x;
 
         return 1;
     }

--- a/tests/hevm/pass/layout1/layout1.sol
+++ b/tests/hevm/pass/layout1/layout1.sol
@@ -1,0 +1,19 @@
+contract A {
+    uint128 x;
+    uint128 y;
+    
+    constructor() {
+        x = 11;
+        y = 42;
+    }
+
+    function swap() external returns (uint) {
+        uint128 temp; 
+
+        temp = x;
+        x = y;
+        y = temp;
+
+        return 1;
+    }
+}

--- a/tests/hevm/pass/layout1/layout1.sol
+++ b/tests/hevm/pass/layout1/layout1.sol
@@ -3,16 +3,14 @@ contract A {
     uint128 y;
     
     constructor() {
-        x = 11;
-        y = 42;
+        x = 0;
+        y = 0;
     }
 
     function swap() external returns (uint) {
-        uint128 temp; 
 
-        temp = x;
-        x = y;
-        y = temp;
+        x = 11;
+        y = 42;
 
         return 1;
     }

--- a/tests/hevm/pass/layout1/layout1.sol
+++ b/tests/hevm/pass/layout1/layout1.sol
@@ -3,14 +3,16 @@ contract A {
     uint128 y;
     
     constructor() {
-        x = 0;
-        y = 0;
+        x = 11;
+        y = 42;
     }
 
     function swap() external returns (uint) {
 
+        uint128 tmp = x;
+        
         x = y;
-        // y = x;
+        y = tmp;
 
         return 1;
     }

--- a/tests/hevm/pass/layout2/layout2.act
+++ b/tests/hevm/pass/layout2/layout2.act
@@ -1,0 +1,31 @@
+constructor of A
+interface constructor()
+
+iff
+
+  CALLVALUE == 0
+
+creates
+
+  uint128 x := 11
+  bool flag := true
+  uint32 u := 17
+  uint8 z := 3
+  uint128 y := 42
+  uint256 i := 128
+
+behaviour foo of A
+interface foo()
+
+iff
+
+  CALLVALUE == 0
+
+  storage
+
+    x => y
+    y => x
+    z => 11
+    flag => not flag
+
+  returns 1

--- a/tests/hevm/pass/layout2/layout2.act
+++ b/tests/hevm/pass/layout2/layout2.act
@@ -21,11 +21,53 @@ iff
 
   CALLVALUE == 0
 
-  storage
+storage
 
-    x => y
-    y => x
-    z => 11
-    flag => not flag
+  x => y
+  y => x
+  z => 11
+  flag => not flag
 
-  returns 1
+returns 1
+
+behaviour set_flag of A
+interface set_flag(bool b)
+
+iff
+
+  CALLVALUE == 0
+
+storage
+
+  flag => b
+
+
+behaviour get_flag of A
+interface get_flag()
+
+iff
+
+  CALLVALUE == 0
+
+returns
+
+  pre(flag)
+
+
+behaviour set_y_if_flag of A
+interface set_y_if_flag(uint128 v)
+
+iff
+
+  CALLVALUE == 0
+
+case flag:
+
+storage
+  y => v
+
+returns 1
+
+case (not flag):
+returns 1
+

--- a/tests/hevm/pass/layout2/layout2.sol
+++ b/tests/hevm/pass/layout2/layout2.sol
@@ -1,0 +1,29 @@
+contract A {
+    uint128 x;
+    bool flag;
+    uint32 u;
+    uint8 z;
+    uint128 y;
+    uint256 i;
+    
+    constructor() {
+        x = 11;
+        flag = true;
+        u = 17;
+        z = 3;
+        y = 42;
+        i = 128;
+    }
+
+    function foo() external returns (uint) {
+
+        uint128 tmp = x;
+        
+        x = y;
+        y = tmp;
+        z = 11;
+        flag = !flag;
+
+        return 1;
+    }
+}

--- a/tests/hevm/pass/layout2/layout2.sol
+++ b/tests/hevm/pass/layout2/layout2.sol
@@ -5,7 +5,7 @@ contract A {
     uint8 z;
     uint128 y;
     uint256 i;
-    
+
     constructor() {
         x = 11;
         flag = true;
@@ -18,11 +18,27 @@ contract A {
     function foo() external returns (uint) {
 
         uint128 tmp = x;
-        
+
         x = y;
         y = tmp;
         z = 11;
         flag = !flag;
+
+        return 1;
+    }
+
+    function set_flag(bool b) external {
+        flag = b;
+    }
+
+    function get_flag() external returns (bool) {
+        return flag;
+    }
+
+    function set_y_if_flag(uint128 v) external returns (uint) {
+        if (flag) {
+            y = v;
+        }
 
         return 1;
     }

--- a/tests/hevm/pass/layout3/layout3.act
+++ b/tests/hevm/pass/layout3/layout3.act
@@ -1,0 +1,42 @@
+constructor of Map
+interface constructor()
+
+iff
+
+  CALLVALUE == 0
+
+creates
+  uint128 val := 11
+  mapping(uint => uint128) f := [11 := 42]
+
+behaviour val of Map
+interface val()
+
+iff
+
+  CALLVALUE == 0
+
+returns pre(val)
+
+behaviour f of Map
+interface f(uint x)
+
+iff
+
+  CALLVALUE == 0
+
+returns pre(f[x])
+
+
+behaviour set of Map
+interface set(uint128 value, uint key)
+
+iff
+
+  CALLVALUE == 0
+
+storage
+
+  f[key] => value
+
+returns 1

--- a/tests/hevm/pass/layout3/layout3.sol
+++ b/tests/hevm/pass/layout3/layout3.sol
@@ -1,0 +1,14 @@
+contract Map {
+    uint128 public val;
+    mapping (uint => uint128) public f;
+    
+    constructor() {
+        val = 11;
+        f[11] = 42;
+    }
+
+    function set(uint128 value, uint key) external returns (uint) {
+        f[key] = value;
+        return 1;
+    }
+}

--- a/tests/hevm/pass/layout4/layout4.act
+++ b/tests/hevm/pass/layout4/layout4.act
@@ -1,0 +1,69 @@
+constructor of Map
+interface constructor()
+
+iff
+
+  CALLVALUE == 0
+
+creates
+  uint128 val := 11
+  mapping(uint => uint128) f := [11 := 42, 42 := 1]
+  mapping(uint128 => bool) g := [22 := true, 1 := false]
+  
+
+behaviour val of Map
+interface val()
+
+iff
+
+  CALLVALUE == 0
+
+returns pre(val)
+
+behaviour f of Map
+interface f(uint x)
+
+iff
+
+  CALLVALUE == 0
+
+returns pre(f[x])
+
+
+behaviour g of Map
+interface g(uint128 x)
+
+iff
+
+  CALLVALUE == 0
+
+returns pre(g[x])
+
+
+
+behaviour setf of Map
+interface setf(uint128 value, uint key)
+
+iff
+
+  CALLVALUE == 0
+
+storage
+
+  f[key] => value
+
+returns 1
+
+
+behaviour setg of Map
+interface setg(bool value,  uint128 key)
+
+iff
+
+  CALLVALUE == 0
+
+storage
+
+  g[key] => value
+
+returns 1

--- a/tests/hevm/pass/layout4/layout4.sol
+++ b/tests/hevm/pass/layout4/layout4.sol
@@ -2,7 +2,7 @@ contract Map {
     uint128 public val;
     mapping (uint => uint128) public f;
     mapping (uint128 => bool) public g;
-    
+
     constructor() {
         val = 11;
         f[11] = 42;

--- a/tests/hevm/pass/layout4/layout4.sol
+++ b/tests/hevm/pass/layout4/layout4.sol
@@ -1,0 +1,23 @@
+contract Map {
+    uint128 public val;
+    mapping (uint => uint128) public f;
+    mapping (uint128 => bool) public g;
+    
+    constructor() {
+        val = 11;
+        f[11] = 42;
+        g[22] = true;
+        g[1] = false;
+        f[42] = 1;
+    }
+
+    function setf(uint128 value, uint key) external returns (uint) {
+        f[key] = value;
+        return 1;
+    }
+
+    function setg(bool value, uint128 key) external returns (uint) {
+        g[key] = value;
+        return 1;
+    }
+}

--- a/tests/hevm/pass/maps/maps.sol
+++ b/tests/hevm/pass/maps/maps.sol
@@ -5,14 +5,13 @@ contract Map {
     mapping (uint => uint) public f;
 
     constructor () {
-	val = 0;
+        val = 0;
         f[0] = 42;
     }
 
 
     function set(uint value, uint key) public returns (uint) {
-	f[key] = value;
-
-	return 1;
+        f[key] = value;
+        return 1;
     }
 }

--- a/tests/hevm/pass/transfer-simple/transfer-simple.sol
+++ b/tests/hevm/pass/transfer-simple/transfer-simple.sol
@@ -9,7 +9,7 @@ contract Token {
 
 
     function transfer(uint256 value, address to) public returns (uint) {
-	balanceOf[msg.sender] = balanceOf[msg.sender] - value;
+	    balanceOf[msg.sender] = balanceOf[msg.sender] - value;
         balanceOf[to] = balanceOf[to] + value;
         return 1;
     }

--- a/tests/hevm/pass/transfer-simple/transfer-simple.sol
+++ b/tests/hevm/pass/transfer-simple/transfer-simple.sol
@@ -9,7 +9,7 @@ contract Token {
 
 
     function transfer(uint256 value, address to) public returns (uint) {
-	    balanceOf[msg.sender] = balanceOf[msg.sender] - value;
+        balanceOf[msg.sender] = balanceOf[msg.sender] - value;
         balanceOf[to] = balanceOf[to] + value;
         return 1;
     }

--- a/tests/invariants/pass/mutex.act
+++ b/tests/invariants/pass/mutex.act
@@ -8,15 +8,13 @@ creates
 
 invariants
 
-	// Ideally this would be `not lock`
-	lock => false
+	not lock
 
 behaviour f of Mutex
 interface setX(uint256 _x)
 
 iff
-	// Ideally this would be `not lock`
-	lock => false
+	not lock
 
 storage
 	x => _x

--- a/tests/postconditions/pass/amm.act
+++ b/tests/postconditions/pass/amm.act
@@ -85,6 +85,8 @@ returns 1
 ensures
 
     pre(token0.balanceOf[THIS]) * pre(token1.balanceOf[THIS]) <= post(token0.balanceOf[THIS]) * post(token1.balanceOf[THIS])
+    post(token0.balanceOf[THIS]) * post(token1.balanceOf[THIS]) <= pre(token0.balanceOf[THIS]) * pre(token1.balanceOf[THIS]) + pre(token0.balanceOf[THIS]) + amt
+
 
 
 behaviour swap1 of Amm
@@ -119,3 +121,4 @@ returns 1
 ensures
 
     pre(token0.balanceOf[THIS]) * pre(token1.balanceOf[THIS]) <= post(token0.balanceOf[THIS]) * post(token1.balanceOf[THIS])
+    post(token0.balanceOf[THIS]) * post(token1.balanceOf[THIS]) <= pre(token0.balanceOf[THIS]) * pre(token1.balanceOf[THIS]) + pre(token1.balanceOf[THIS]) + amt


### PR DESCRIPTION
This PR implements Solidity's [memory layout of storage variables](https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html) is the translation of Act to Expr. This is necessary for proving the equivalence of our specs to Solidity smart contracts.

### Summary of Changes:

 - Implement Solidity-compliant storage layout for base types and mappings.
 - Resolve minor issues related to boolean translation.
 - Enforce precondition bounds for booleans.
 - Add multiple tests covering various layout scenarios.

In the future, it would be ideal to further generalize the translation, by making it parametric on the memory layout (e.g., loading it from a JSON file).

Closes #175, #189.