### PR TITLE
Correction in 'make clean' in Rocq tests

### DIFF
--- a/tests/coq/ERC20/Makefile
+++ b/tests/coq/ERC20/Makefile
@@ -11,5 +11,5 @@ CoqMakefile: _CoqProject
 .PHONY: clean
 clean:
 	if [[ -f CoqMakefile ]]; then make -f CoqMakefile clean; fi
-	rm -f StateMachine.v CoqMakefile CoqMakefile.conf
+	rm -f ERC20.v CoqMakefile CoqMakefile.conf
 	rm -f *.glob *.vo *.vok *.vos

--- a/tests/coq/multi/Makefile
+++ b/tests/coq/multi/Makefile
@@ -11,5 +11,5 @@ CoqMakefile: _CoqProject
 .PHONY: clean
 clean:
 	if [[ -f CoqMakefile ]]; then make -f CoqMakefile clean; fi
-	rm -f Exponent.v CoqMakefile CoqMakefile.conf
+	rm -f Multi.v CoqMakefile CoqMakefile.conf
 	rm -f *.glob *.vo *.vok *.vos

--- a/tests/coq/token/Makefile
+++ b/tests/coq/token/Makefile
@@ -11,5 +11,5 @@ CoqMakefile: _CoqProject
 .PHONY: clean
 clean:
 	if [[ -f CoqMakefile ]]; then make -f CoqMakefile clean; fi
-	rm -f StateMachine.v CoqMakefile CoqMakefile.conf
+	rm -f Token.v CoqMakefile CoqMakefile.conf
 	rm -f *.glob *.vo *.vok *.vos


### PR DESCRIPTION
Correction in Makefiles of Rocq tests.
The 'make clean' commands did not remove the .v files produced by Act correctly in some tests.