### PR TITLE
Fix error reporting for equivalence checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,6 @@ test-invariant: parser compiler $(invariant_pass:=.invariant.pass) $(invariant_f
 test-postcondition: parser compiler $(postcondition_pass:=.postcondition.pass) $(postcondition_fail:=.postcondition.fail)
 test-equiv: parser compiler $(hevm_pass:=.hevm.pass) $(hevm_vy_pass:=.hevm.vy.pass) $(hevm_multi_pass:=.hevm.multi.pass) $(hevm_fail:=.hevm.fail)
 test-equiv-fast: parser compiler $(hevm_fast:=.hevm.pass.fast) $(hevm_vy_pass:=.hevm.vy.pass) $(hevm_multi_fast:=.hevm.multi.pass) $(hevm_fail:=.hevm.fail)
-test-cabal: src/*.hs
-	cabal v2-run test
 
 # Just checks parsing
 tests/%.parse.pass:
@@ -143,4 +141,4 @@ tests/hevm/pass/%.act.hevm.pass.fast:
 	./bin/act equiv --spec tests/hevm/pass/$*.act --sol tests/hevm/pass/$*.sol --solver bitwuzla --smttimeout 100000000
 
 test-ci: test-parse test-type test-rocq test-equiv-fast
-test: test-ci test-cabal
+test: test-ci

--- a/act.cabal
+++ b/act.cabal
@@ -2,7 +2,7 @@ cabal-version: 2.2
 
 name:       act
 version:    0.2.0
-authors:    Lefteris Lazaropoulos, Zoe Paraskevopoulou, Anja Petkovic Komel, Sophie Rain, dxo, Martin Lundfall
+author:    Lefteris Lazaropoulos, Zoe Paraskevopoulou, Anja Petkovic Komel, Sophie Rain, dxo, Martin Lundfall
 maintainer: zoe.paraskevopoulou@argot.org
 
 flag ci
@@ -89,23 +89,3 @@ executable act
   build-depends:      act
   if os(darwin)
       extra-libraries: c++
-
--- Test-Suite test
---   import:           common
---   type:             exitcode-stdio-1.0
---   default-language: Haskell2010
---   main-is:          Main.hs
---   hs-source-dirs:   src/Test
---   other-modules:    Decompile
---   build-depends:    act,
---                     pretty-simple          >= 2.2,
---                     quickcheck-instances   >= 0.3,
---                     quickcheck-transformer >= 0.3,
---                     tasty-hunit            >= 0.10,
---                     tasty-expected-failure,
---                     tasty-quickcheck       >= 0.10,
---                     QuickCheck             >= 2.13.2,
---                     tasty                  >= 1.2,
---                     here                   >= 1.2
---   if os(darwin)
---       extra-libraries: c++

--- a/src/Act/CLI.hs
+++ b/src/Act/CLI.hs
@@ -153,7 +153,7 @@ parse' f jsn = do
   fs <- processSources jsn f
   contents <- flip zip fs <$> mapM readFile fs
   let parsed = traverse (\(content,source) -> (,source) <$> (errorSource source $ parse $ lexer content)) contents
-  validation (prettyErrs contents) print parsed
+  validation (prettyErrs (Just contents)) print parsed
 
 type' :: Maybe FilePath -> Maybe FilePath -> Solvers.Solver -> Maybe Integer -> Bool -> IO ()
 type' f jsn solver' smttimeout' debug' = do
@@ -213,7 +213,7 @@ equivCheck actspec sol' vy' code' initcode' layout' sources' solver' timeout deb
       checkContracts solvers store cmap
     case res of
       Success _ -> pure ()
-      Failure err -> prettyErrs [("","")] (second ("",) <$> err)
+      Failure err -> prettyErrs Nothing (second ("",) <$> err)
   where
 
     -- Creates maps of storage layout modes and bytecodes, for all contracts contained in the given Act specification
@@ -395,7 +395,7 @@ toCode fromFile t = case BS16.decodeBase16Untyped (encodeUtf8 (stripSuffixIf "\n
 
 -- | Fail on error, or proceed with continuation
 proceed :: Validate err => [(String,FilePath)] -> err (NonEmpty (Pn, (FilePath, String))) a -> (a -> IO ()) -> IO ()
-proceed contents comp continue = validation (prettyErrs contents) continue (comp ^. revalidate)
+proceed contents comp continue = validation (prettyErrs (Just contents)) continue (comp ^. revalidate)
 
 compile :: [(String, FilePath)] -> Error (FilePath ,String) (Act, [Constraint Timed])
 compile = pure . (first annotate) <==< pure . (\(acts, cnstr) -> (acts, (checkIntegerBoundsAct acts) ++ cnstr))

--- a/src/Act/Error.hs
+++ b/src/Act/Error.hs
@@ -87,8 +87,8 @@ concatError def = \case
   x:xs -> foldl (*>) x xs
 
 
-prettyErrs :: Traversable t => [(String, FilePath)] -> t (Pn, (FilePath, String)) -> IO ()
-prettyErrs sources errs = mapM_ prettyErr errs >> exitFailure
+prettyErrs :: Traversable t => Maybe [(String, FilePath)] -> t (Pn, (FilePath, String)) -> IO ()
+prettyErrs (Just sources) errs = mapM_ prettyErr errs >> exitFailure
   where
   prettyErr (pn, (_, msg)) | pn == nowhere = do
     hPutStrLn stderr "Internal error:"
@@ -115,3 +115,10 @@ prettyErrs sources errs = mapM_ prettyErr errs >> exitFailure
       safeDrop _ [] = []
       safeDrop _ [a] = [a]
       safeDrop n (_:xs) = safeDrop (n-1) xs
+prettyErrs Nothing errs = mapM_ prettyErr errs >> exitFailure
+  where
+  prettyErr (pn, (_, msg)) | pn == nowhere = do
+    hPutStrLn stderr "Internal error:"
+    hPutStrLn stderr msg
+  prettyErr (_, (_, msg)) = do
+    hPutStrLn stderr msg


### PR DESCRIPTION
This PR fixes error reporting for failures during equivalence checking, where source information is not required.
It also removes the now deprecated decompilation tests from the main test suite.