### PR TITLE
line-buffer stdout so progress is visible when output is redirected

### DIFF
--- a/src/Act/CLI.hs
+++ b/src/Act/CLI.hs
@@ -19,6 +19,7 @@ import GHC.Generics
 import System.Exit ( exitFailure )
 import System.Process
 import System.FilePath
+import System.IO (hSetBuffering, BufferMode(LineBuffering), stdout)
 import Data.Text.Encoding (encodeUtf8)
 import Data.Validation
 import qualified Data.Map as Map
@@ -119,6 +120,11 @@ deriving instance Show (Command Unwrapped)
 
 main :: IO ()
 main = do
+    -- Line-buffer stdout: when output is a pipe or file, GHC block-buffers it,
+    -- so progress messages ("Checking behavior ...") only appear once a 8KiB
+    -- block fills or the process exits. On long equiv runs that makes a healthy
+    -- run indistinguishable from a hung one.
+    hSetBuffering stdout LineBuffering
     cmd <- unwrapRecord "Act -- Smart contract specifier"
     case cmd of
       Lex f jsn -> lex' f jsn


### PR DESCRIPTION
GHC block-buffers stdout when it is not a terminal, so 'Checking behavior ...' progress lines are withheld until a block fills or the process exits. Piping an equiv run to a log therefore shows nothing for minutes to hours, and a healthy run looks identical to a hung one (this cost real debugging time on a multi-hour proof). Line buffering makes progress visible without changing any output.